### PR TITLE
DHP-1088 Survey Builder - set ‘en’ label equal to the overview title

### DIFF
--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateSurveyResource,
 } from '@services/assessmentHooks'
 import {ChoiceQuestion, Question, Step, Survey} from '@typedefs/surveys'
-import {Assessment, AssessmentImageResource, ExtendedError} from '@typedefs/types'
+import {Assessment, ExtendedError} from '@typedefs/types'
 import React, {FunctionComponent} from 'react'
 import {useIsFetching, useIsMutating} from 'react-query'
 import {Redirect, Route, RouteComponentProps, Switch, useHistory, useLocation, useParams} from 'react-router-dom'
@@ -228,9 +228,13 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
         throw new Error('no assessment')
       }
       if (isOverviewStep) {
+        
+        var updatedAssessment = assessment
+        var hasAssessmentChanges = false
+
         const {image} = step
         if (image) {
-          const imageResource: AssessmentImageResource = {
+          updatedAssessment.imageResource = {
             name: image.imageName,
             module: 'sage_survey',
             labels: [
@@ -241,11 +245,22 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
             ],
             type: 'ImageResource',
           }
+          hasAssessmentChanges = true
+        }
 
-          const updatedAssessment = {
-            ...assessment,
-            imageResource: imageResource,
-          }
+        // TODO: syoung 10/02/2023 FIXME!!! Replace this with localized replacement
+        let currentLabel = assessment.labels.find(label => label.lang === 'en')
+        if (currentLabel?.value !== step.title) {
+          updatedAssessment.labels = [...assessment.labels.filter(label => label.lang !== 'en'),
+            {
+              lang: 'en',
+              value: step.title,
+            },
+          ]
+          hasAssessmentChanges = true
+        }
+
+        if (hasAssessmentChanges) {
           setAssessment(updatedAssessment)
           mutateAssessment(
             {assessment: updatedAssessment, action: 'UPDATE'},

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -229,8 +229,8 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
       }
       if (isOverviewStep) {
         
-        var updatedAssessment = assessment
-        var hasAssessmentChanges = false
+        let updatedAssessment = assessment
+        let hasAssessmentChanges = false
 
         const {image} = step
         if (image) {

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -260,6 +260,11 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
           hasAssessmentChanges = true
         }
 
+        // TODO: syoung 10/04/2023 FIXME!!! Replace this with a summary field on the settings page.
+        if (step.detail && assessment.summary !== step.detail) {
+          updatedAssessment.summary = step.detail
+        }
+
         if (hasAssessmentChanges) {
           setAssessment(updatedAssessment)
           mutateAssessment(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -118,7 +118,10 @@ export type AssessmentResource = {
 }
 export type Assessment = {
   appId?: string
-  labels?: string[]
+  labels: {
+    lang: Language
+    value: string
+  }[]
   identifier: string
   revision: number
   osName?: 'Android' | 'iPhone OS' | 'Both' | 'Universal' //iPhone OS"


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1088

This is our short-term solution (until we design how to support localization) for setting the "label" for an assessment so that the title shown to the participant in the timeline matches the survey title page rather than the "name" shown to the researcher when scheduling or editing.