### PR TITLE
DHP-1053 Do not add an assessment to the list of assessments

### DIFF
--- a/src/services/assessmentHooks.ts
+++ b/src/services/assessmentHooks.ts
@@ -203,7 +203,7 @@ export const useUpdateSurveyAssessment = () => {
           newState = newState.filter(a => a.guid !== props.assessment.guid)
           break
         case 'COPY':
-          newState.unshift({...props.assessment, identifier: '...'})
+          // no additional actions needed.
           break
         case 'UPDATE':
           queryClient.setQueryData(


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1053

When copying, a copy of the assessment was being added with the identifier changed to "..." - the `guid`, which is the identifier used by Bridge, was not replaced by the "placeholder" and this copy was never removed.

Opened https://sagebionetworks.jira.com/browse/DHP-1093 to track improving the UI/UX for copying surveys