### PR TITLE
Add surveys to schedule

### DIFF
--- a/src/components/assessments/AssessmentLibraryWrapper.tsx
+++ b/src/components/assessments/AssessmentLibraryWrapper.tsx
@@ -1,3 +1,4 @@
+import CollapsableMenu from '@components/surveys/widgets/MenuDropdown'
 import {StyledToggleButton, StyledToggleButtonGroup} from '@components/widgets/StyledComponents'
 import {useUserSessionDataState} from '@helpers/AuthContext'
 import useFeatureToggles, {FeatureToggles} from '@helpers/FeatureToggle'
@@ -82,6 +83,19 @@ const StyledToggle = styled(StyledToggleButton, {label: 'StyleToggle1'})<{width?
   },
 }))
 
+const sections = [
+  {
+    assessmentType: 'SHARED' as AssessmentsType,
+    title: 'All Assessments',
+    filterTitle: 'Assessments',
+  },
+  {
+    assessmentType: 'SURVEY' as AssessmentsType,
+    title: 'All Surveys',
+    filterTitle: 'Surveys',
+  },
+]
+
 const AssessmentTypeToggle: FunctionComponent<{
   assessmentType: AssessmentsType
   onChange: (a: AssessmentsType) => void
@@ -94,24 +108,24 @@ const AssessmentTypeToggle: FunctionComponent<{
     onChange(value)
   }
   return (
-    <Box mb={3} mt={1}>
-      <StyledToggleButtonGroup
-        width={190}
-        value={assessmentType}
-        exclusive
-        onChange={(e, _val) => {
-          sendUpdate(_val)
-        }}
-        aria-label="choose your assessment category">
-        <StyledToggle value={'SHARED'} aria-label="shared assessments">
-          &nbsp; Assessments
-        </StyledToggle>
-
-        <StyledToggle value={'SURVEY'} aria-label="surveys">
-          &nbsp; Surveys
-        </StyledToggle>
-      </StyledToggleButtonGroup>
-    </Box>
+    <Box
+    aria-label="choose your assessment category"
+    id="menucontainer"
+    sx={{
+      position: 'relative',
+      height: '120px',
+      borderBottom: '1px solid #DFE2E6',
+      padding: theme.spacing(0, 4),
+      paddingTop: [theme.spacing(0), theme.spacing(4), theme.spacing(4), theme.spacing(6.75)],
+    }}>
+    <CollapsableMenu
+      items={sections.map(s => ({...s, enabled: true, id: s.filterTitle}))}
+      selectedFn={section => assessmentType === section.assessmentType }
+      displayMobileItem={(section, isSelected) => <>{section.filterTitle}</>}
+      displayDesktopItem={(section, isSelected) => <Box sx={{minWidth: '120px'}}> {section.filterTitle}</Box>}
+      onClick={section => sendUpdate(section.assessmentType)}
+    />
+  </Box>
   )
 }
 
@@ -127,7 +141,6 @@ const AssessmentLibraryWrapper: FunctionComponent<AssessmentLibraryWrapperProps>
   onChangeAssessmentsType,
 }: AssessmentLibraryWrapperProps) => {
   const {token} = useUserSessionDataState()
-  const surveyToggle = useFeatureToggles<FeatureToggles>()
 
   return (
     <StyledOuterContainer isBlue={!token && false /* TODO are they different?*/}>

--- a/src/components/assessments/AssessmentLibraryWrapper.tsx
+++ b/src/components/assessments/AssessmentLibraryWrapper.tsx
@@ -103,7 +103,7 @@ const AssessmentTypeToggle: FunctionComponent<{
           sendUpdate(_val)
         }}
         aria-label="allow skipping question">
-        <StyledToggle value={'OTHER'} aria-label="make required">
+        <StyledToggle value={'SHARED'} aria-label="make required">
           &nbsp; Assessments
         </StyledToggle>
 
@@ -118,7 +118,7 @@ const AssessmentTypeToggle: FunctionComponent<{
 const AssessmentLibraryWrapper: FunctionComponent<AssessmentLibraryWrapperProps> = ({
   children,
   isAssessmentLibrary = true,
-  assessmentsType = 'OTHER',
+  assessmentsType = 'SHARED',
   onChangeViewMode,
   viewMode = 'GRID',
   tags,
@@ -137,29 +137,26 @@ const AssessmentLibraryWrapper: FunctionComponent<AssessmentLibraryWrapperProps>
         assessments={assessments}
         onChangeTags={(tags: string[]) => onChangeTags(tags)}
       /> */}
-      <Box
-        sx={{
-          background: 'linear-gradient(360deg, #EDEEF2 22.68%, #FAFAFB 85.05%)',
-          padding: theme.spacing(5.5, 5, 4.5, 5),
-          display: 'flex',
-          justifyContent: 'space-between',
-        }}>
-        <Box>
-          <Typography variant="h2" sx={{marginBottom: theme.spacing(3)}}>
-            Assessments
-          </Typography>
-          <Typography component={'p'} sx={{fontSize: '16px'}}>
-            Need some text here
-          </Typography>
-        </Box>
-        {isAssessmentLibrary && token && (
+      {isAssessmentLibrary && token && (
+        <Box
+          sx={{
+            background: 'linear-gradient(360deg, #EDEEF2 22.68%, #FAFAFB 85.05%)',
+            padding: theme.spacing(5.5, 5, 4.5, 5),
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}>
+          <Box>
+            <Typography variant="h2">
+              Assessments
+            </Typography>
+          </Box>    
           <NavLink to={'assessments/preview'} style={{textDecoration: 'none'}}>
             <Button variant="outlined">Demo All Assessments</Button>
           </NavLink>
+        </Box>
         )}
-      </Box>
       <StyledAssessmentContainer maxWidth="xl">
-        {surveyToggle['SURVEY BUILDER'] && false && (
+        {!isAssessmentLibrary && (
           <AssessmentTypeToggle assessmentType={assessmentsType} onChange={t => onChangeAssessmentsType(t)} />
         )}
 

--- a/src/components/assessments/AssessmentLibraryWrapper.tsx
+++ b/src/components/assessments/AssessmentLibraryWrapper.tsx
@@ -102,12 +102,12 @@ const AssessmentTypeToggle: FunctionComponent<{
         onChange={(e, _val) => {
           sendUpdate(_val)
         }}
-        aria-label="allow skipping question">
-        <StyledToggle value={'SHARED'} aria-label="make required">
+        aria-label="choose your assessment category">
+        <StyledToggle value={'SHARED'} aria-label="shared assessments">
           &nbsp; Assessments
         </StyledToggle>
 
-        <StyledToggle value={'SURVEY'} aria-label="allow skip">
+        <StyledToggle value={'SURVEY'} aria-label="surveys">
           &nbsp; Surveys
         </StyledToggle>
       </StyledToggleButtonGroup>

--- a/src/components/studies/session-creator/AssessmentSelector.tsx
+++ b/src/components/studies/session-creator/AssessmentSelector.tsx
@@ -98,7 +98,7 @@ const AssessmentSelector: FunctionComponent<AssessmentSelectorProps> = ({
   const [assessmentsType, setAssessmentsType] = React.useState<AssessmentsType>('SHARED')
   const {data, isLoading, status} = useAssessmentsWithResources(false, false)
   const [viewMode, setViewMode] = React.useState<ViewType>('GRID')
-  const {data: surveys} = useAssessmentsWithResources(false, true)
+  const {data: surveys} = useAssessmentsWithResources(true, true)
 
   if ((!data?.assessments || !data?.tags) && status === 'success') {
     return <>No Data </>

--- a/src/components/studies/session-creator/AssessmentSelector.tsx
+++ b/src/components/studies/session-creator/AssessmentSelector.tsx
@@ -95,7 +95,7 @@ const AssessmentSelector: FunctionComponent<AssessmentSelectorProps> = ({
 }: AssessmentSelectorProps) => {
   const surveyToggle = useFeatureToggles<FeatureToggles>()
   const [filteredAssessments, setFilteredAssessments] = useState<Assessment[] | undefined>(undefined)
-  const [assessmentsType, setAssessmentsType] = React.useState<AssessmentsType>('OTHER')
+  const [assessmentsType, setAssessmentsType] = React.useState<AssessmentsType>('SHARED')
   const {data, isLoading, status} = useAssessmentsWithResources(false, false)
   const [viewMode, setViewMode] = React.useState<ViewType>('GRID')
   const {data: surveys} = useAssessmentsWithResources(false, true)
@@ -107,10 +107,10 @@ const AssessmentSelector: FunctionComponent<AssessmentSelectorProps> = ({
   const isAssessmentInSession = (session: StudySession, assessmentId: string): boolean =>
     session.assessments?.find(item => item.originGuid === assessmentId) !== undefined
   const getAssessments = () => {
-    if ((assessmentsType === 'OTHER' && !data) || (assessmentsType === 'SURVEY' && !surveys)) {
+    if ((assessmentsType === 'SHARED' && !data) || (assessmentsType === 'SURVEY' && !surveys)) {
       return []
     }
-    if (assessmentsType === 'OTHER') {
+    if (assessmentsType === 'SHARED') {
       return filteredAssessments || data!.assessments
     } else {
       return filteredAssessments || surveys!.assessments

--- a/src/components/studies/session-creator/SingleSessionContainer.tsx
+++ b/src/components/studies/session-creator/SingleSessionContainer.tsx
@@ -216,7 +216,7 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
                   {!studySession.assessments ||
                     (studySession.assessments.length === 0 && (
                       <Box marginTop={7} padding={2}>
-                        Add assessments to this session by clicking on the "+" below.{' '}
+                        Add assessments and surveys to this session by clicking on the "+" below.{' '}
                       </Box>
                     ))}
                   {studySession.assessments?.map((assessment, index) => (

--- a/src/helpers/FeatureToggle.tsx
+++ b/src/helpers/FeatureToggle.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react'
 
-export type ToggleKey = 'SURVEY BUILDER' | 'USERNAME PASSWORD LOGIN' | 'OTHER'
+export type ToggleKey = 'SURVEY BUILDER' | 'USERNAME PASSWORD LOGIN' | 'SHARED'
 
 export type FeatureToggles = Partial<Record<ToggleKey, undefined | boolean>>
 

--- a/src/services/assessment.service.ts
+++ b/src/services/assessment.service.ts
@@ -1,7 +1,7 @@
 import Utility from '@helpers/utility'
 import constants from '@typedefs/constants'
 import {Survey} from '@typedefs/surveys'
-import {Assessment, AssessmentResource, ExtendedError} from '@typedefs/types'
+import {Assessment, AssessmentBase, AssessmentResource, ExtendedError} from '@typedefs/types'
 
 /* AG: BOTH survey and assessments would include arb/mtb tag, but surveys would include survey tag while other assessments won't*/
 const ASSESSMENT_APP_TAG = {
@@ -31,18 +31,19 @@ async function getAssessment(
   options: {isLocal: boolean; shouldKeepAllTags?: boolean}
 ): Promise<Assessment> {
   let endPoint = options.isLocal ? constants.endpoints.assessment : constants.endpoints.assessmentShared
-  const assessmentResponse = await Utility.callEndpoint<Assessment>(
+  const assessmentResponse = await Utility.callEndpoint<AssessmentBase>(
     `${endPoint.replace(':id', guid)}`,
     'GET',
     {},
     token
   )
   // should keep all tags if set 'true' will return assessment. Otherwise it'll fiter the tags
-  const assessment = {
+  const assessment: Assessment = {
     ...assessmentResponse.data,
     tags: options.shouldKeepAllTags
       ? assessmentResponse.data.tags
       : assessmentResponse.data.tags.filter(tag => !TAGS_TO_HIDE.includes(tag)),
+    isLocal: options.isLocal
   }
 
   return assessment
@@ -53,31 +54,31 @@ async function getAssessments(
   appId: string,
   token: string,
   options: {isLocal?: boolean; isSurvey?: boolean} = {}
-  //  isLocal = false
 ): Promise<Assessment[]> {
   const _options = {...DEFAULT_ASSESSMENT_RETR_OPTIONS, ...options}
-  const result = await Utility.callEndpoint<{items: Assessment[]}>(
-    _options?.isLocal ? constants.endpoints.assessments : constants.endpoints.assessmentsShared,
+  const result = await Utility.callEndpoint<{items: AssessmentBase[]}>(
+    _options.isLocal ? constants.endpoints.assessments : constants.endpoints.assessmentsShared,
     'GET',
     {},
     token
   )
 
   const filterTag = _options?.isSurvey ? SURVEY_APP_TAG[appId] : ASSESSMENT_APP_TAG[appId]
-  const returnResult = result.data.items
+  const returnResult: Assessment[] = result.data.items
 
     .filter(item => item.tags && item.tags.includes(filterTag))
     .map(item => ({
       ...item,
       tags: item.tags?.filter(tag => !TAGS_TO_HIDE.includes(tag)),
+      isLocal: _options.isLocal,
     }))
 
   return returnResult
 }
 
 /*gets resources for an assessment (shared) or survey (local) */
-async function getResource(assessment: Assessment, token: string, isLocal = false): Promise<Assessment> {
-  const endPoint = isLocal ? constants.endpoints.assessmentResources : constants.endpoints.assessmentSharedResources
+async function getResource(assessment: Assessment, token: string): Promise<Assessment> {
+  const endPoint = assessment.isLocal ? constants.endpoints.assessmentResources : constants.endpoints.assessmentSharedResources
   const response = await Utility.callEndpoint<{items: any[]}>(
     endPoint.replace(':identifier', assessment.identifier),
     'GET',

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -99,7 +99,7 @@ export interface UserSessionData extends UserData {
 }
 
 /* *** Assessment ********************************/
-export type AssessmentsType = 'SURVEY' | 'OTHER'
+export type AssessmentsType = 'SURVEY' | 'SHARED'
 export type ResourceFormat = 'image/png'
 export type AssessmentCategory = 'screenshot' | 'icon' | 'website'
 export type AssessmentResource = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -116,7 +116,7 @@ export type AssessmentResource = {
   url: string
   version?: number
 }
-export type Assessment = {
+export type AssessmentBase = {
   appId?: string
   labels?: string[]
   identifier: string
@@ -142,6 +142,12 @@ export type Assessment = {
   resources?: AssessmentResource[]
   originGuid?: string
   imageResource?: AssessmentImageResource
+}
+
+export type Assessment = AssessmentBase & {
+
+  // Not part of the object JSON returned by the service
+  isLocal: boolean
 }
 
 export type AssessmentConfig = {


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1091

## Terminology Reminder
Within the Researcher UI, the following are equivalent:
- "Survey" means a local assessment where all the calls need to use the `/v1/assessment` or  `/v1/assessments` endpoints.
- "Assessment" means a shared assessment where all the calls need to use either `/v1/sharedassessment` or  `/v1/sharedassessments` endpoints.

Since the model object returned by both of these services is the same JSON, the website needs to track whether or not the origin is "shared" or "local". Thanks to @hallieswan for explaining how to subclass the server `Assessment` to add the required field for `isLocal` so that subsequent calls to get information about the assessment can point at the correct services.