### PR TITLE
DHP-1089 Fix "Rename" survey to actually allow renaming

### DIFF
--- a/src/components/assessments/AssessmentLibrary.tsx
+++ b/src/components/assessments/AssessmentLibrary.tsx
@@ -47,7 +47,7 @@ const AssessmentLibrary: FunctionComponent<AssessmentLibraryProps> = ({match}: A
       {data && (
         <AssessmentLibraryWrapper
           assessments={data.assessments}
-          assessmentsType="OTHER"
+          assessmentsType='SHARED'
           viewMode={viewMode}
           onChangeViewMode={setViewMode}
           onChangeAssessmentsType={() => {}}

--- a/src/components/studies/StudyCard.tsx
+++ b/src/components/studies/StudyCard.tsx
@@ -53,7 +53,6 @@ const StudyCard: FunctionComponent<StudyCardProps> = ({
   isRename,
   onRename,
   isNewlyAddedStudy,
-
   isMenuOpen,
 }) => {
   const date = new Date(study.phase === 'design' ? study.modifiedOn! : study.createdOn!)

--- a/src/components/studies/StudyList.tsx
+++ b/src/components/studies/StudyList.tsx
@@ -319,14 +319,14 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
     handleMenuClose()
     switch (type) {
       case 'RENAME':
-        await mutate({action: 'RENAME', study: {...study, name: study.name}})
+        mutate({action: 'RENAME', study: {...study, name: study.name}})
         setRenameStudyId('')
 
         return
       case 'WITHDRAW':
       case 'CLOSE':
       case 'DELETE':
-        await mutate({action: type, study})
+        mutate({action: type, study})
         return
 
       case 'DUPLICATE':

--- a/src/components/studies/StudyList.tsx
+++ b/src/components/studies/StudyList.tsx
@@ -374,8 +374,8 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
           <CollapsableMenu
             items={sections.map(s => ({...s, enabled: true, id: s.filterTitle}))}
             selectedFn={section => isSelectedFilter(section)}
-            displayMobileItem={(section, isSelected) => <>{section.filterTitle}</>}
-            displayDesktopItem={(section, isSelected) => <Box sx={{minWidth: '120px'}}> {section.filterTitle}</Box>}
+            displayMobileItem={(section, _isSelected) => <>{section.filterTitle}</>}
+            displayDesktopItem={(section, _isSelected) => <Box sx={{minWidth: '120px'}}> {section.filterTitle}</Box>}
             onClick={section => (section.sectionStatus ? setStatusFilter(section.sectionStatus) : resetStatusFilters())}
           />
 

--- a/src/components/surveys/SurveyCard.tsx
+++ b/src/components/surveys/SurveyCard.tsx
@@ -1,6 +1,7 @@
 import CardWithMenu, {StatusColor} from '@components/widgets/CardWithMenu'
+import Utility from '@helpers/utility'
 import {Box, styled} from '@mui/material'
-import {Assessment, DisplayStudyPhase} from '@typedefs/types'
+import {Assessment, AssessmentEditPhase, DisplayStudyPhase} from '@typedefs/types'
 import dayjs from 'dayjs'
 import {FunctionComponent} from 'react'
 
@@ -29,16 +30,28 @@ type SurveyCardProps = {
 
   isMenuOpen: boolean
 }
-export const getColorForStudyPhase = (status: DisplayStudyPhase): StatusColor => {
+export const getColorForSurveyPhase = (status?: AssessmentEditPhase): StatusColor => {
   switch (status) {
-    case 'COMPLETED':
+    case 'published':
       return '#47A4DD'
-    case 'DRAFT':
+    case 'draft':
       return '#C22E49'
-    case 'LIVE':
+    case 'review':
       return '#63A650'
     default:
       return '#4f527d'
+  }
+}
+export const getTitleForSurveyPhase = (status?: AssessmentEditPhase): string => {
+  switch (status) {
+    case 'published':
+      return 'Published'
+    case 'draft':
+      return 'Draft'
+    case 'review':
+      return 'Preview'
+    default:
+      return 'Unknown'
   }
 }
 
@@ -63,14 +76,12 @@ const SurveyCard: FunctionComponent<SurveyCardProps> = ({
 
   const rightBottomChild = (
     <ParticipantsIconContainer>
-      <strong>Created by</strong>
+      <strong>Created by&nbsp;</strong>
       {survey.ownerId}
     </ParticipantsIconContainer>
   )
 
-  const displayStatus = 'Unknown'
   const shouldHaveSpaceAfterName = false
-  const statusColor = getColorForStudyPhase('WITHDRAWN')
   return (
     <CardWithMenu
       identifierLabel='Survey ID'
@@ -81,8 +92,8 @@ const SurveyCard: FunctionComponent<SurveyCardProps> = ({
       onRename={onRename}
       isRename={isRename}
       shouldHighlight={shouldHighlight}
-      topStatus={displayStatus}
-      statusColor={statusColor}
+      topStatus={Utility.capitalize(survey.phase ?? 'unknown')}
+      statusColor={getColorForSurveyPhase(survey.phase as AssessmentEditPhase)}
       shouldHaveSpaceAfterName={shouldHaveSpaceAfterName}
       leftBottomChild={leftBottomChild}
       rightBottomChild={rightBottomChild}

--- a/src/components/surveys/SurveyCard.tsx
+++ b/src/components/surveys/SurveyCard.tsx
@@ -61,7 +61,6 @@ const SurveyCard: FunctionComponent<SurveyCardProps> = ({
   isRename,
   onRename,
   shouldHighlight,
-
   isMenuOpen,
 }) => {
   const date = new Date(survey.modifiedOn ? survey.modifiedOn! : survey.createdOn!)

--- a/src/components/surveys/SurveyList.tsx
+++ b/src/components/surveys/SurveyList.tsx
@@ -6,12 +6,24 @@ import Link from '@mui/material/Link'
 import {useAssessments, useUpdateSurveyAssessment} from '@services/assessmentHooks'
 import {theme} from '@style/theme'
 import constants from '@typedefs/constants'
-import {Assessment} from '@typedefs/types'
-import React from 'react'
+import {Assessment, AssessmentEditPhase} from '@typedefs/types'
+import React, { FunctionComponent } from 'react'
 import {useErrorHandler} from 'react-error-boundary'
 import {Redirect, useHistory} from 'react-router-dom'
 import SurveyCard from './SurveyCard'
 import CollapsableMenu from './widgets/MenuDropdown'
+
+type SurveySublistProps = {
+  status: AssessmentEditPhase | null
+  surveys: Assessment[]
+  onCardClick: Function
+  renameId: string
+  highlightedId: string | null
+  menuAnchor: {
+    survey: Assessment
+    anchorEl: HTMLElement
+  } | null
+}
 
 const cardWidth = '357'
 
@@ -30,13 +42,14 @@ const StyledSurveysContainer = styled(Box, {label: 'StyledStudyListGrid'})(({the
 }))
 
 const AssessmentMenu: React.FunctionComponent<{
-  anchorEl: Element
+  anchorEl: Element,
+  survey: Assessment,
   onDelete: () => void
   onView: () => void
   onClose: () => void
   onDuplicate: () => void
   onRename: () => void
-}> = ({onDelete, onView, onDuplicate, onClose, onRename, anchorEl}) => {
+}> = ({onDelete, onView, onDuplicate, onClose, onRename, anchorEl, survey}) => {
   return (
     <Menu
       id="assessment-menu"
@@ -55,15 +68,19 @@ const AssessmentMenu: React.FunctionComponent<{
       <MenuItem onClick={onView} key="view">
         View
       </MenuItem>
+      { !survey.isReadOnly && 
       <MenuItem onClick={onRename} key="rename">
         Rename
       </MenuItem>
+      }
       <MenuItem onClick={onDuplicate} key="duplicate">
         Duplicate
       </MenuItem>
+      { !survey.isReadOnly && 
       <MenuItem onClick={onDelete} key="delete">
         Delete
       </MenuItem>
+      }
     </Menu>
   )
 }
@@ -76,20 +93,57 @@ const sections = [
   {
     title: 'Draft',
     filterTitle: 'Draft',
+    sectionStatus: 'draft' as AssessmentEditPhase,
   },
   {
     title: 'Published',
     filterTitle: 'Published',
-  },
-  {
-    title: 'Created By Me',
-    filterTitle: 'Created By Me',
-  },
-  {
-    title: 'Shared With Me',
-    filterTitle: 'Shared With Me',
+    sectionStatus: 'published' as AssessmentEditPhase,
   },
 ]
+
+type SublistAction = 'DELETE' | 'ANCHOR' | 'DUPLICATE' | 'RENAME' | 'VIEW' 
+
+const SurveySublist: FunctionComponent<SurveySublistProps> = ({
+  status,
+  surveys,
+  onCardClick,
+  renameId,
+  highlightedId,
+  menuAnchor,
+}: SurveySublistProps) => {
+  const displayItems = status ? surveys.filter(survey => status == survey.phase) : surveys
+
+  if (displayItems?.length === 0) {
+    return <></>
+  }
+
+  return (
+    <StyledSurveysContainer key="container">
+      {displayItems?.map((survey, _index) => (
+        <Link
+          component="button"
+          style={{textDecoration: 'none'}}
+          key={survey.guid}
+          variant="body2"
+          onClick={() => (survey.identifier === '...' ? '' : onCardClick({...survey}, 'VIEW'))}
+          underline="hover">
+          <SurveyCard
+            key={survey.guid}
+            shouldHighlight={highlightedId === survey.guid}
+            survey={survey}
+            isMenuOpen={menuAnchor?.survey?.guid === survey.guid}
+            onSetAnchor={(e: HTMLElement) => {
+              onCardClick(survey, 'ANCHOR', e)
+            }}
+            isRename={renameId === survey.guid}
+            onRename={(newName: string) => onCardClick({...survey, title: newName}, 'RENAME')}
+          />
+        </Link>
+      ))}
+    </StyledSurveysContainer>
+  )
+}
 
 const SurveyList: React.FunctionComponent<{}> = () => {
   const handleError = useErrorHandler()
@@ -101,8 +155,9 @@ const SurveyList: React.FunctionComponent<{}> = () => {
     survey: Assessment
     anchorEl: HTMLElement
   }>(null)
-  const [highlightedStudyId, setHighlightedStudyId] = React.useState<string | null>(null)
+  const [highlightedId, setHighlightedId] = React.useState<string | null>(null)
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = React.useState<'DELETE' | undefined>(undefined)
+  const [statusFilter, setStatusFilter] = React.useState<AssessmentEditPhase | null>(null)
 
   const {
     data: surveys,
@@ -130,7 +185,7 @@ const SurveyList: React.FunctionComponent<{}> = () => {
     switch (type) {
       case 'DELETE':
         // await mutate({ action: type, study })
-        mutateAssessment(
+        await mutateAssessment(
           {assessment: survey, action: 'DELETE'},
           {
             onSuccess: data => {
@@ -142,7 +197,7 @@ const SurveyList: React.FunctionComponent<{}> = () => {
         break
       case 'RENAME':
         await mutateAssessment(
-          {action: 'UPDATE', survey: {...survey, title: survey.title}},
+          {assessment: survey, action: 'UPDATE'},
           {
             onSuccess: data => {
               // alert('done')
@@ -154,16 +209,16 @@ const SurveyList: React.FunctionComponent<{}> = () => {
 
         return
       case 'DUPLICATE':
-        mutateAssessment(
+        await mutateAssessment(
           {
             assessment: {...survey, title: `Copy of ${survey.title}`},
             action: 'COPY',
           },
           {
             onSuccess: data => {
-              setHighlightedStudyId(data.guid!)
+              setHighlightedId(data.guid!)
               setTimeout(() => {
-                setHighlightedStudyId(null)
+                setHighlightedId(null)
               }, 2000)
               // alert('done')
             },
@@ -176,6 +231,27 @@ const SurveyList: React.FunctionComponent<{}> = () => {
         console.log('unknow study action')
       }
     }
+  }
+
+  const resetStatusFilters = () => {
+    setStatusFilter(null)
+  }
+  const isSelectedFilter = (section: typeof sections[1]) => {
+    if (!section.sectionStatus) {
+      return !statusFilter
+    }
+    return statusFilter === section.sectionStatus
+  }
+
+  const navigateToSurvey = (survey?: Assessment) => {
+    if (survey && survey.guid !== renameSurveyId) {
+      history.push(`/surveys/${survey.guid}/design/intro`)
+    }
+  }
+
+  const beginEditingName = (survey: Assessment) => {
+    setRenameSurveyId(survey.guid!)
+    handleMenuClose()
   }
 
   return (
@@ -195,11 +271,11 @@ const SurveyList: React.FunctionComponent<{}> = () => {
         }}>
         <CollapsableMenu
           items={sections.map(s => ({...s, enabled: true, id: s.filterTitle}))}
-          selectedFn={section => /*isSelectedFilter(section)*/ false}
-          displayMobileItem={(section, isSelected) => <>{section.filterTitle}</>}
-          displayDesktopItem={(section, isSelected) => <Box sx={{minWidth: '120px'}}> {section.filterTitle}</Box>}
+          selectedFn={section => isSelectedFilter(section)}
+          displayMobileItem={(section, _isSelected) => <>{section.filterTitle}</>}
+          displayDesktopItem={(section, _isSelected) => <Box sx={{minWidth: '120px'}}> {section.filterTitle}</Box>}
           onClick={
-            section => {} /*(section.sectionStatus ? setStatusFilter(section.sectionStatus) : resetStatusFilters())*/
+            section => (section.sectionStatus ? setStatusFilter(section.sectionStatus) : resetStatusFilters())
           }
         />
 
@@ -215,38 +291,41 @@ const SurveyList: React.FunctionComponent<{}> = () => {
       <Loader reqStatusLoading={getSurveysStatus === 'loading'}>
         <Box sx={{backgroundColor: '#FBFBFC', paddingTop: theme.spacing(7)}}>
           <Container maxWidth="lg">
-            <StyledSurveysContainer key="container">
-              {surveys?.map((survey, index) => (
-                <Link
-                  component="button"
-                  style={{textDecoration: 'none'}}
-                  key={survey.guid}
-                  variant="body2"
-                  onClick={() => history.push(`/surveys/${survey.guid}/design/intro`)}
-                  underline="hover">
-                  <SurveyCard
-                    key={survey.guid}
-                    shouldHighlight={highlightedStudyId === survey.guid}
-                    survey={survey}
-                    isMenuOpen={menuAnchor?.survey?.guid === survey.guid}
-                    onSetAnchor={(e: any) => setMenuAnchor({survey, anchorEl: e})}
-                    isRename={renameSurveyId === survey.guid}
-                    onRename={(name: string) => onAction({...survey, title: name}, 'RENAME')}
-                  />
-                </Link>
-              ))}
-            </StyledSurveysContainer>
+            <SurveySublist 
+              surveys={surveys!}
+              renameId={renameSurveyId}
+              status={statusFilter}
+              onCardClick={(s: Assessment, action: SublistAction, e: any) => {
+                switch (action) {
+                  case 'ANCHOR':
+                    setMenuAnchor({survey: s, anchorEl: e})
+                    break
+                  case 'VIEW':
+                    handleMenuClose()
+                    navigateToSurvey(s)
+                    break
+                  case 'RENAME':
+                    onAction(s, 'RENAME')
+                    break
+                  default:
+                    console.log('unknown study action')
+                }
+              }}
+              highlightedId={highlightedId}
+              menuAnchor={menuAnchor}
+            />
           </Container>
         </Box>
       </Loader>
       {menuAnchor && (
         <AssessmentMenu
           anchorEl={menuAnchor.anchorEl}
+          survey={menuAnchor!.survey}
           onClose={handleMenuClose}
-          onRename={() => setRenameSurveyId(menuAnchor!.survey.guid!)}
+          onRename={() => beginEditingName(menuAnchor!.survey)}
           onDelete={() => setIsConfirmDialogOpen('DELETE')}
           onDuplicate={() => onAction(menuAnchor!.survey, 'DUPLICATE')}
-          onView={() => history.push(`/surveys/${menuAnchor?.survey.guid}/design/intro`)}
+          onView={() => navigateToSurvey(menuAnchor!.survey)}
         />
       )}
 

--- a/src/components/surveys/SurveyList.tsx
+++ b/src/components/surveys/SurveyList.tsx
@@ -13,12 +13,12 @@ import {Redirect, useHistory} from 'react-router-dom'
 import SurveyCard from './SurveyCard'
 import CollapsableMenu from './widgets/MenuDropdown'
 
-const studyCardWidth = '357'
+const cardWidth = '357'
 
 const StyledSurveysContainer = styled(Box, {label: 'StyledStudyListGrid'})(({theme}) => ({
   display: 'grid',
   padding: theme.spacing(0),
-  gridTemplateColumns: `repeat(auto-fill,${studyCardWidth}px)`,
+  gridTemplateColumns: `repeat(auto-fill,${cardWidth}px)`,
   gridColumnGap: theme.spacing(2),
   gridRowGap: theme.spacing(2),
   justifyContent: 'center',

--- a/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.test.tsx
+++ b/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.test.tsx
@@ -89,7 +89,7 @@ test('additional options for integer multiselect', async () => {
   const {user} = setUp(step)
   const btnDots = screen.getByRole('button', {name: /more/i})
 
-  await user.click(btnDots)
+  await act(async () => user.click(btnDots))
 
   expect(screen.queryByRole('menuitem', {name: /all of the above/i})).toBeInTheDocument()
   expect(screen.queryByRole('menuitem', {name: /none of the above/i})).toBeInTheDocument()
@@ -100,7 +100,7 @@ test('additional options for string multiselect', async () => {
   const {user} = setUp({...step, baseType: 'string'})
   const btnDots = screen.getByRole('button', {name: /more/i})
 
-  await user.click(btnDots)
+  await act(async () => user.click(btnDots))
 
   expect(screen.queryByRole('menuitem', {name: /all of the above/i})).toBeInTheDocument()
   expect(screen.queryByRole('menuitem', {name: /none of the above/i})).toBeInTheDocument()
@@ -111,7 +111,7 @@ test('additional options for integer single select', async () => {
   const {user} = setUp({...step, baseType: 'integer', singleChoice: true})
   const btnDots = screen.getByRole('button', {name: /more/i})
 
-  await user.click(btnDots)
+  await act(async () => user.click(btnDots))
 
   expect(screen.queryByRole('menuitem', {name: /all of the above/i})).not.toBeInTheDocument()
   expect(screen.queryByRole('menuitem', {name: /none of the above/i})).not.toBeInTheDocument()
@@ -122,7 +122,7 @@ test('additional options for string single select', async () => {
   const {user} = setUp({...step, baseType: 'string', singleChoice: true})
   const btnDots = screen.getByRole('button', {name: /more/i})
 
-  await user.click(btnDots)
+  await act(async () => user.click(btnDots))
 
   expect(screen.queryByRole('menuitem', {name: /all of the above/i})).not.toBeInTheDocument()
   expect(screen.queryByRole('menuitem', {name: /none of the above/i})).not.toBeInTheDocument()

--- a/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
+++ b/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
@@ -69,14 +69,14 @@ const StyledMenu = styled(Menu, {label: 'StyledMenu'})(({theme}) => ({
 
 const StyledMenuItem = styled(MenuItem, {label: 'StyledMenuItem'})<{
   height?: string
-  nohover?: boolean
-}>(({theme, height = '48px', nohover = false}) => ({
+  nohover?: string
+}>(({height = '48px', nohover = undefined}) => ({
   height: height,
   backgroundColor: '#9499C7',
   color: '#fff',
   '&:hover': {
-    backgroundColor: nohover ? '#9499C7' : '#848484',
-    cursor: nohover ? 'default' : 'pointer',
+    backgroundColor: (nohover == "true") ? '#9499C7' : '#848484',
+    cursor: (nohover == "true") ? 'default' : 'pointer',
   },
   '&.Mui-disabled': {
     opacity: 1,
@@ -136,7 +136,7 @@ const OPTIONS = new Map<
 
 const NoMenuItemOptions: FunctionComponent = () => {
   return (
-    <StyledMenuItem height="80px" key={'NO_OPTIONS'} nohover={true} onClick={void 0} disabled={true}>
+    <StyledMenuItem height="80px" key={'NO_OPTIONS'} nohover={'true'} onClick={void 0} disabled={true}>
       <Box height="60px" >
         <Box
           sx={{

--- a/src/components/widgets/CardWithMenu.tsx
+++ b/src/components/widgets/CardWithMenu.tsx
@@ -150,16 +150,16 @@ const CardWithMenu: FunctionComponent<CardWithMenuProps> = ({
 
   const handleKeyDown = (event: React.KeyboardEvent, newName: string | undefined) => {
     if (!onRename) {
+      // exit early if not renaming the survey or study
       return
     }
     const {key} = event
-
-    const enterKey = 'Enter'
-
     if (key === 'Escape') {
+      // cancel rename by setting the name to the current name
       onRename(name)
-    }
-    if (key === 'Tab' || key === enterKey) {
+    } 
+    else if (key === 'Tab' || key === 'Enter') {
+      // rename the object to the new name
       onRename(newName)
     }
   }

--- a/src/services/assessment.service.ts
+++ b/src/services/assessment.service.ts
@@ -1,7 +1,7 @@
 import Utility from '@helpers/utility'
 import constants from '@typedefs/constants'
 import {Survey} from '@typedefs/surveys'
-import {Assessment, AssessmentBase, AssessmentResource, ExtendedError} from '@typedefs/types'
+import {Assessment, AssessmentBase, AssessmentEditPhase, AssessmentResource, ExtendedError} from '@typedefs/types'
 
 /* AG: BOTH survey and assessments would include arb/mtb tag, but surveys would include survey tag while other assessments won't*/
 const ASSESSMENT_APP_TAG = {
@@ -24,12 +24,18 @@ const TAGS_TO_HIDE = [...Object.values(SURVEY_APP_TAG), ...Object.values(ASSESSM
 const DEFAULT_ASSESSMENT_RETR_OPTIONS = {isLocal: false, isSurvey: false}
 
 function convertAssessment(input: AssessmentBase, shouldKeepAllTags = false) : Assessment {
+  const isLocal = input.appId !== 'shared'
+  const phase = (isLocal ? input.phase as AssessmentEditPhase ?? 'draft' : 'published')
+  const isReadOnly = (phase !== 'draft' || !isLocal)
+  // TODO: syoung 10/06/2023 Revisit these rules for defining default phase and readonly to allow administrators permission to edit shared assessments.
   return {
     ...input,
     tags: shouldKeepAllTags
       ? input.tags
       : input.tags.filter(tag => !TAGS_TO_HIDE.includes(tag)),
-    isLocal: input.appId !== 'shared'
+    phase: phase,
+    isLocal: isLocal,
+    isReadOnly: isReadOnly
   }
 }
 

--- a/src/services/assessmentHooks.ts
+++ b/src/services/assessmentHooks.ts
@@ -184,6 +184,7 @@ export const useUpdateSurveyAssessment = () => {
       case 'UPDATE':
         console.log('updating', assessment)
         return AssessmentService.updateSurveyAssessment(appId, assessment, token!)
+        
       case 'CREATE':
         return AssessmentService.createSurveyAssessment(appId, assessment, token!)
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -102,6 +102,7 @@ export interface UserSessionData extends UserData {
 export type AssessmentsType = 'SURVEY' | 'SHARED'
 export type ResourceFormat = 'image/png'
 export type AssessmentCategory = 'screenshot' | 'icon' | 'website'
+export type AssessmentEditPhase = 'draft' | 'review' | 'published'
 export type AssessmentResource = {
   category: AssessmentCategory
   deleted?: boolean
@@ -145,6 +146,7 @@ export type AssessmentBase = {
   resources?: AssessmentResource[]
   originGuid?: string
   imageResource?: AssessmentImageResource
+  phase?: string
 }
 
 export type Assessment = AssessmentBase & {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -117,6 +117,10 @@ export type AssessmentResource = {
   url: string
   version?: number
 }
+
+/** 
+ * The `Assessment` object returned by services.
+*/
 export type AssessmentBase = {
   appId?: string
   labels: {
@@ -149,10 +153,17 @@ export type AssessmentBase = {
   phase?: string
 }
 
+/**
+ * The `Assessment` object used throughout this app that includes additional fields
+ * needed to support determining which endpoint to call, as well as editing state.
+ * 
+ * These properties are not part of the object JSON returned by services.
+ * This mutation is hardcoded into a function in the code file: `assessment.services.ts`
+ * syoung 10/06/2023
+ */
 export type Assessment = AssessmentBase & {
-
-  // Not part of the object JSON returned by the service
   isLocal: boolean
+  isReadOnly: boolean
 }
 
 export type AssessmentConfig = {


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1089 - The issue that I was originally looking at was that if you are on the survey list view and you select "Rename" from the menu, it doesn't work. Instead it was not hiding the menu and would navigate to the detail view for the survey.

I tried to match what it was doing on the Study list view (the code for "Survey Builder" list was copy/pasted from that code file), discovered a ton of warnings in tests and other discrepancies, and ended up down a bit of a renaming rabbit hole.

That said, the main "fixes" were:
- call through to services with the correct property names ("assessment", not "survey")
- don't navigate to the detail if the "Title" field is highlighted (ie. textfield rather than label)

Note: The UI/UX for a "rename" of a survey or study is a bit weird. There's no explicit blocking pop-up like there is on Google drive so you can sit there clicking away all day and you are blocked from selecting that study or survey in order to view the detail until:

1.  You have tapped into the the text field to focus that input field
2. And then you enter (using your keyboard) either "esc" to cancel editing the title or "return" or "tab" to accept the changes.

I believe this is "by design" and not (strictly speaking) a bug.