### PR TITLE
read-only surveys

### DIFF
--- a/src/components/studies/StudyBuilderHeader.tsx
+++ b/src/components/studies/StudyBuilderHeader.tsx
@@ -6,12 +6,11 @@ import {DisplayStudyPhase, Study} from '@typedefs/types'
 import AccessSettings from '@components/access-settings/AccessSettings'
 import DialogTitleWithClose from '@components/widgets/DialogTitleWithClose'
 import Utility from '@helpers/utility'
-import ErrorTwoToneIcon from '@mui/icons-material/ErrorTwoTone'
 import {styled} from '@mui/material'
 import StudyService from '@services/study.service'
-import {theme} from '@style/theme'
 import React from 'react'
 import {useHistory} from 'react-router-dom'
+import ReadOnlyBanner from '@components/widgets/ReadOnlyBanner'
 
 const BG_COLOR: Record<DisplayStudyPhase, string> = {
   DRAFT: 'rgba(194, 46, 73, .1)',
@@ -52,20 +51,7 @@ const StudyBuilderHeader: React.FunctionComponent<{study: Study; isReadOnly?: bo
           </Button>
         )}
       </StyledStudyHeader>
-      {isReadOnly && (
-        <Box
-          sx={{
-            backgroundColor: 'rgba(255, 168, 37, 0.15)',
-            textAlign: 'left',
-            fontSize: '16px',
-
-            display: 'flex',
-            padding: theme.spacing(1, 8),
-          }}>
-          <ErrorTwoToneIcon sx={{color: '#FFA825'}}></ErrorTwoToneIcon>&nbsp;&nbsp;This study is in read-only mode and
-          can not be edited.
-        </Box>
-      )}
+      {isReadOnly && <ReadOnlyBanner label='study' /> }
       <Dialog open={isOpenAS} fullWidth={true} maxWidth="lg" scroll="body">
         <DialogTitleWithClose onCancel={() => setIsOpenAS(false)} title={'    Access Settings'} />
         <AccessSettings study={study} />

--- a/src/components/surveys/survey-design/IntroInfo.tsx
+++ b/src/components/surveys/survey-design/IntroInfo.tsx
@@ -229,10 +229,12 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps & RouteComponentProps> =
   }, [_surveyAssessment, survey])
 
   const updateState = (callback: Function) => {
+    if (basicInfo.isReadOnly) return
     setHasObjectChanged(true)
     callback()
   }
   const updateInterruptonHandling = (key: keyof InterruptionHandlingType, value: boolean) => {
+    if (basicInfo.isReadOnly) return
     setHasObjectChanged(true)
     if (key !== 'reviewIdentifier') {
       setInterruptionHandling(prev => ({...prev, [key]: value}))
@@ -450,6 +452,7 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps & RouteComponentProps> =
           id="survey tags"
           options={[]}
           freeSolo
+          disabled={basicInfo.isReadOnly}
           onChange={(e, v) => updateState(() => setBasicInfo(prev => ({...prev, tags: v})))}
           value={[...basicInfo.tags]}
           renderTags={(value: string[], getTagProps) =>
@@ -463,7 +466,7 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps & RouteComponentProps> =
         />
       </StyledFormControl>
 
-      <SaveButton assessment={basicInfo} onClick={() => triggerUpdate()} />
+      { !basicInfo.isReadOnly && <SaveButton assessment={basicInfo} onClick={() => triggerUpdate()} />}
     </IntroContainer>
   )
 }

--- a/src/components/surveys/survey-design/IntroInfo.tsx
+++ b/src/components/surveys/survey-design/IntroInfo.tsx
@@ -168,12 +168,16 @@ const getDefaultSurvey = (newSurveyId: string): Survey => ({
 })
 const getDefaultAssessment = (newSurveyId: string, orgMembership: string): Assessment => ({
   title: '',
+  labels: [],
   tags: [],
   version: 0,
   revision: 1,
   osName: 'Both',
   identifier: newSurveyId,
   ownerId: orgMembership,
+  phase: 'draft',
+  isLocal: true,
+  isReadOnly: false,
 })
 
 const InterruptionHandlingDefault: InterruptionHandlingType = {

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -27,6 +27,7 @@ import QUESTIONS, {QuestionTypeKey} from './left-panel/QuestionConfigs'
 import QuestionEditPhone from './question-edit/QuestionEditPhone'
 import QuestionEditRhs from './question-edit/QuestionEditRhs'
 import QuestionEditToolbar from './question-edit/QuestionEditToolbar'
+import ReadOnlyBanner from '@components/widgets/ReadOnlyBanner'
 
 const SurveyDesignContainerBox = styled(Box, {
   label: 'SurveyDesignContainerBox',
@@ -405,9 +406,12 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
           guid={surveyGuid}
           surveyConfig={survey?.config}
           onReorderSteps={(steps: Step[]) => updateAllStepsAndSave(steps)}>
-          <AddQuestion>
-            <AddQuestionMenu onSelectQuestion={qType => addStepWithDefaultConfig(qType)} />
-          </AddQuestion>
+              { assessment?.isReadOnly ? 
+              <ReadOnlyBanner label='survey' /> :
+              <AddQuestion>
+                <AddQuestionMenu onSelectQuestion={qType => addStepWithDefaultConfig(qType)} />
+              </AddQuestion>
+              }
         </LeftPanel>
         {/* CEDNTRAL PHONE AREA*/}
 

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -405,6 +405,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
           currentStepIndex={currentStepIndex}
           guid={surveyGuid}
           surveyConfig={survey?.config}
+          isReadOnly={assessment?.isReadOnly ?? true}
           onReorderSteps={(steps: Step[]) => updateAllStepsAndSave(steps)}>
               { assessment?.isReadOnly ? 
               <ReadOnlyBanner label='survey' /> :

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -422,6 +422,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
                 <SaveIndicator numOfMutations={numOfMutations + numOfFecheds} hasObjectChanged={hasObjectChanged} />
                 {survey && (
                   <QuestionEditPhone
+                    isReadOnly={assessment?.isReadOnly ?? true}
                     isDynamic={isDynamicStep()}
                     globalSkipConfiguration={survey!.config.webConfig?.skipOption || 'CUSTOMIZE'}
                     onChange={(step: Step) => {
@@ -435,6 +436,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
               <RightContainer>
                 {survey && (
                   <QuestionEditRhs
+                    isReadOnly={assessment?.isReadOnly ?? true}
                     isDynamic={isDynamicStep()}
                     dependentQuestions={findDependentQuestions()}
                     step={getCurrentStep()!}

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -442,7 +442,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
                     dependentQuestions={findDependentQuestions()}
                     step={getCurrentStep()!}
                     onChange={(step: Step) => updateCurrentStep(step)}>
-                    {getCurrentStep()?.type !== 'completion' && (
+                    {getCurrentStep()?.type !== 'completion' && !assessment?.isReadOnly && (
                       <QuestionEditToolbar
                         isDynamic={isDynamicStep()}
                         dependentQuestions={findDependentQuestions()}

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -209,7 +209,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
   }
 
   const updateCurrentStep = (step: Step, stepIndex?: number) => {
-    if (!survey) {
+    if (!survey || assessment?.isReadOnly) {
       return
     }
 

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -135,11 +135,12 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
   }>()
 
   const isNewSurvey = () => surveyGuid === ':id'
-
+  
   const history = useHistory()
   const location = useLocation()
   const [assessment, setAssessment] = React.useState<Assessment | undefined>()
   const [survey, setSurvey] = React.useState<Survey | undefined>()
+  const isReadOnly = assessment?.isReadOnly ?? false
 
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number | undefined>(
     getQuestionIndexFromSearchString(location.search)
@@ -209,7 +210,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
   }
 
   const updateCurrentStep = (step: Step, stepIndex?: number) => {
-    if (!survey || assessment?.isReadOnly) {
+    if (!survey || isReadOnly) {
       return
     }
 
@@ -386,6 +387,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
     return dependentSteps
   }
 
+  
   return (
     <Loader reqStatusLoading={!isNewSurvey() && !survey}>
       <NavigationPrompt when={hasObjectChanged && !numOfMutations} key="nav_prompt">
@@ -405,9 +407,9 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
           currentStepIndex={currentStepIndex}
           guid={surveyGuid}
           surveyConfig={survey?.config}
-          isReadOnly={assessment?.isReadOnly ?? true}
+          isReadOnly={isReadOnly}
           onReorderSteps={(steps: Step[]) => updateAllStepsAndSave(steps)}>
-              { assessment?.isReadOnly ? 
+              { isReadOnly ? 
               <ReadOnlyBanner label='survey' /> :
               <AddQuestion>
                 <AddQuestionMenu onSelectQuestion={qType => addStepWithDefaultConfig(qType)} />
@@ -423,7 +425,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
                 <SaveIndicator numOfMutations={numOfMutations + numOfFecheds} hasObjectChanged={hasObjectChanged} />
                 {survey && (
                   <QuestionEditPhone
-                    isReadOnly={assessment?.isReadOnly ?? true}
+                    isReadOnly={isReadOnly}
                     isDynamic={isDynamicStep()}
                     globalSkipConfiguration={survey!.config.webConfig?.skipOption || 'CUSTOMIZE'}
                     onChange={(step: Step) => {
@@ -437,12 +439,12 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
               <RightContainer>
                 {survey && (
                   <QuestionEditRhs
-                    isReadOnly={assessment?.isReadOnly ?? true}
+                    isReadOnly={isReadOnly}
                     isDynamic={isDynamicStep()}
                     dependentQuestions={findDependentQuestions()}
                     step={getCurrentStep()!}
                     onChange={(step: Step) => updateCurrentStep(step)}>
-                    {getCurrentStep()?.type !== 'completion' && !assessment?.isReadOnly && (
+                    {getCurrentStep()?.type !== 'completion' && !isReadOnly && (
                       <QuestionEditToolbar
                         isDynamic={isDynamicStep()}
                         dependentQuestions={findDependentQuestions()}

--- a/src/components/surveys/survey-design/left-panel/LeftPanel.tsx
+++ b/src/components/surveys/survey-design/left-panel/LeftPanel.tsx
@@ -109,15 +109,20 @@ const TitleRow: React.FunctionComponent<{
   )
 }
 
+function canDrag(isReadOnly: boolean, size: number, index: number) {
+  return !isReadOnly && size > 3 && index > 0 && index < size - 1
+}
+
 const StepLink: React.FunctionComponent<{
   //guid: string
   index: number
   step: Step
   size: number
   isCurrentStep: boolean
+  isReadOnly: boolean
   provided: DraggableProvided
   onClick: () => void
-}> = ({index, step, size, isCurrentStep, provided, onClick}) => {
+}> = ({index, step, size, isCurrentStep, isReadOnly, provided, onClick}) => {
   let title = `${index < 9 ? '0' : ''}${index}. ${step.title}`
   if (index === size - 1) {
     title = 'Completion Screen'
@@ -145,7 +150,7 @@ const StepLink: React.FunctionComponent<{
             {QUESTIONS.get(getQuestionId(step))?.img}
             <StyledQuestionText>{title}</StyledQuestionText>
           </DivContainer>
-          {size > 3 && index > 0 && index < size - 1 && <DraggableIcon sx={{color: '#DFE2E6'}} />}
+          {canDrag(isReadOnly, size, index) && <DraggableIcon sx={{color: '#DFE2E6'}} />}
         </DivContainer>
       </StyledNavAnchor>
     </Row>
@@ -157,9 +162,10 @@ const LeftPanel: React.FunctionComponent<{
   surveyId?: string
   surveyConfig?: SurveyConfig
   currentStepIndex?: number
+  isReadOnly: boolean
   onReorderSteps: (s: Step[]) => void
   onNavigateStep: (id: number) => void
-}> = ({guid, surveyConfig, children, surveyId, currentStepIndex, onNavigateStep, onReorderSteps}) => {
+}> = ({guid, surveyConfig, children, surveyId, currentStepIndex, isReadOnly, onNavigateStep, onReorderSteps}) => {
   const onDragEnd = (result: DropResult) => {
     if (!surveyConfig?.steps) {
       return
@@ -196,13 +202,12 @@ const LeftPanel: React.FunctionComponent<{
                       {surveyConfig!.steps!.map((step, index) => (
                         <Draggable
                           draggableId={step.identifier}
-                          isDragDisabled={
-                            surveyConfig?.steps!.length < 3 || step.type === 'overview' || step.type === 'completion'
-                          }
+                          isDragDisabled={!canDrag(isReadOnly, surveyConfig?.steps!.length, index)}
                           index={index}
                           key={step.identifier}>
                           {provided => (
                             <StepLink
+                              isReadOnly={isReadOnly}
                               provided={provided}
                               isCurrentStep={currentStepIndex === index}
                               //  guid={guid}

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -229,6 +229,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
               <ScrollableArea height={isDynamic ? 410 : 400} >
                 {isDynamic && (
                   <>    
+                    {(!isReadOnly || step.subtitle) && (
                     <StyledP2
                       aria-label="subtitle"
                       id="subtitle"
@@ -238,6 +239,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       placeholder="Subtitle"
                       onChange={e => onChange({...step, subtitle: e.target.value})}
                     />
+                    )}
                     <StyledH1
                       aria-label="title"
                       id="title"
@@ -247,6 +249,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       placeholder="Title"
                       onChange={e => onChange({...step, title: e.target.value})}
                     />
+                    {(!isReadOnly || step.detail) && (
                     <StyledP2
                       aria-label="detail"
                       id="detail"
@@ -257,6 +260,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       sx={{marginBottom: theme.spacing(2.5), fontSize: '16px', fontWeight: 400}}
                       onChange={e => onChange({...step, detail: e.target.value})}
                     />
+                    )}
                   </>
                 )}
 

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -103,25 +103,17 @@ function isSelectQuestion(questionType: QuestionTypeKey | 0): boolean {
   return questionType === 'MULTI_SELECT' || questionType === 'SINGLE_SELECT'
 }
 
-export type ReadOnlyFlag =
-  | 'true'
-  | 'false'
-
-export const getReadOnlyFlag = (isReadOnly: boolean): ReadOnlyFlag => {
-  return isReadOnly ? 'true' : 'false'
-}
-
 function Factory(args: {
   step: Step
   onChange: (step: Step) => void
 
   q_type: QuestionTypeKey
-  readonly_flag?: ReadOnlyFlag
+  isReadOnly: boolean
 }) {
   switch (args.q_type) {
     case 'SINGLE_SELECT':
     case 'MULTI_SELECT':
-      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'SLIDER':
     case 'LIKERT':
@@ -129,7 +121,7 @@ function Factory(args: {
 
     case 'NUMERIC':
     case 'YEAR':
-      return <Numeric step={args.step as NumericQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Numeric step={args.step as NumericQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'DURATION':
     case 'TIME':
@@ -142,7 +134,7 @@ function Factory(args: {
       return <Completion step={args.step as BaseStep} onChange={args.onChange} />
 
     case 'OVERVIEW': 
-      return <SurveyTitle step={args.step as BaseStep} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <SurveyTitle step={args.step as BaseStep} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'INSTRUCTION': 
       return <></> // Instructions do not have any fields in addition to title, subtitle, and detail.
@@ -274,7 +266,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       step: {...step},
                       onChange: onChange,
                       q_type: getQuestionId(step),
-                      readonly_flag: getReadOnlyFlag(isReadOnly),
+                      isReadOnly: isReadOnly,
                     }}></Factory>
                 }
               </ScrollableArea>

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -227,7 +227,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                 {isDynamic && (
                   <>    
                     <StyledP2
-                      area-label="subtitle"
+                      aria-label="subtitle"
                       id="subtitle"
                       multiline={true}
                       value={step.subtitle || ''}
@@ -235,7 +235,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       onChange={e => onChange({...step, subtitle: e.target.value})}
                     />
                     <StyledH1
-                      area-label="title"
+                      aria-label="title"
                       id="title"
                       multiline={true}
                       value={step.title || ''}
@@ -243,7 +243,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       onChange={e => onChange({...step, title: e.target.value})}
                     />
                     <StyledP2
-                      area-label="detail"
+                      aria-label="detail"
                       id="detail"
                       multiline={true}
                       value={step.detail || ''}

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -231,6 +231,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                     <StyledP2
                       aria-label="subtitle"
                       id="subtitle"
+                      readOnly={isReadOnly}
                       multiline={true}
                       value={step.subtitle || ''}
                       placeholder="Subtitle"
@@ -239,6 +240,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                     <StyledH1
                       aria-label="title"
                       id="title"
+                      readOnly={isReadOnly}
                       multiline={true}
                       value={step.title || ''}
                       placeholder="Title"
@@ -247,6 +249,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                     <StyledP2
                       aria-label="detail"
                       id="detail"
+                      readOnly={isReadOnly}
                       multiline={true}
                       value={step.detail || ''}
                       placeholder="Description"

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -103,11 +103,11 @@ function isSelectQuestion(questionType: QuestionTypeKey | 0): boolean {
   return questionType === 'MULTI_SELECT' || questionType === 'SINGLE_SELECT'
 }
 
-type ReadOnlyFlag =
+export type ReadOnlyFlag =
   | 'true'
   | 'false'
 
-const getReadOnlyFlag = (isReadOnly: boolean): ReadOnlyFlag => {
+export const getReadOnlyFlag = (isReadOnly: boolean): ReadOnlyFlag => {
   return isReadOnly ? 'true' : 'false'
 }
 

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -119,34 +119,34 @@ function Factory(args: {
   readonly_flag?: ReadOnlyFlag
 }) {
   switch (args.q_type) {
-    case 'SINGLE_SELECT': {
-      return <Select step={args.step as ChoiceQuestion} onChange={args.onChange} />
-    }
-
+    case 'SINGLE_SELECT':
     case 'MULTI_SELECT':
-      return <Select step={args.step as ChoiceQuestion} onChange={args.onChange} />
+      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+
     case 'SLIDER':
     case 'LIKERT':
       return <Scale step={args.step as ScaleQuestion} onChange={args.onChange} />
+
     case 'NUMERIC':
-      return <Numeric step={args.step as NumericQuestion} onChange={args.onChange} />
-    case 'DURATION':
-      return <TimeDuration />
-    case 'TIME':
-      return <TimeDuration type="TIME" />
     case 'YEAR':
-      return <Numeric step={args.step as NumericQuestion} onChange={args.onChange} />
+      return <Numeric step={args.step as NumericQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+
+    case 'DURATION':
+    case 'TIME':
+      return <TimeDuration type={args.q_type} />
+
     case 'FREE_TEXT':
       return <FreeText step={args.step as Question} />
-    case 'COMPLETION': {
+
+    case 'COMPLETION': 
       return <Completion step={args.step as BaseStep} onChange={args.onChange} />
-    }
-    case 'OVERVIEW': {
+
+    case 'OVERVIEW': 
       return <SurveyTitle step={args.step as BaseStep} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
-    }
-    case 'INSTRUCTION': {
+
+    case 'INSTRUCTION': 
       return <></> // Instructions do not have any fields in addition to title, subtitle, and detail.
-    }
+      
     default:
       return <>TODO: {args.q_type} not supported</>
   }
@@ -208,7 +208,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
 
   return (
     <OuterContainer>
-      {isSelectQuestion(questionId) && (
+      {isSelectQuestion(questionId) && !isReadOnly && (
         <SelectExtraActions
           onSort={dir => {
             const opts = sortSelectChoices(step as ChoiceQuestion, dir)

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -90,6 +90,7 @@ const ScrollableArea = styled('div', {
 }))
 
 type QuestionEditProps = {
+  isReadOnly: boolean
   isDynamic: boolean
   step?: Step
   globalSkipConfiguration: WebUISkipOptions
@@ -170,6 +171,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
   globalSkipConfiguration,
   completionProgress,
   isDynamic,
+  isReadOnly,
   onChange,
 }) => {
   const questionId = step ? getQuestionId(step) : 0

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -214,7 +214,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
 
       {step && (
         <>
-          <PhoneDisplay sx={{marginBottom: theme.spacing(4), textAlign: 'left'}} phoneBottom={getPhoneBottom()}>
+          <PhoneDisplay sx={{marginBottom: theme.spacing(4), textAlign: 'left'}} phoneBottom={!isReadOnly && getPhoneBottom()}>
             <Box>
               {isDynamic && (
                 <>
@@ -271,7 +271,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
             </Box>
           </PhoneDisplay>
 
-          {globalSkipConfiguration === 'CUSTOMIZE' && isDynamic && (
+          {globalSkipConfiguration === 'CUSTOMIZE' && isDynamic && !isReadOnly && (
             <RequiredToggle
               shouldHideActionsArray={step.shouldHideActions || []}
               onChange={shouldHideActions =>

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -103,11 +103,20 @@ function isSelectQuestion(questionType: QuestionTypeKey | 0): boolean {
   return questionType === 'MULTI_SELECT' || questionType === 'SINGLE_SELECT'
 }
 
+type ReadOnlyFlag =
+  | 'true'
+  | 'false'
+
+const getReadOnlyFlag = (isReadOnly: boolean): ReadOnlyFlag => {
+  return isReadOnly ? 'true' : 'false'
+}
+
 function Factory(args: {
   step: Step
   onChange: (step: Step) => void
 
   q_type: QuestionTypeKey
+  readonly_flag?: ReadOnlyFlag
 }) {
   switch (args.q_type) {
     case 'SINGLE_SELECT': {
@@ -133,7 +142,7 @@ function Factory(args: {
       return <Completion step={args.step as BaseStep} onChange={args.onChange} />
     }
     case 'OVERVIEW': {
-      return <SurveyTitle step={args.step as BaseStep} onChange={args.onChange} />
+      return <SurveyTitle step={args.step as BaseStep} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
     }
     case 'INSTRUCTION': {
       return <></> // Instructions do not have any fields in addition to title, subtitle, and detail.
@@ -265,6 +274,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
                       step: {...step},
                       onChange: onChange,
                       q_type: getQuestionId(step),
+                      readonly_flag: getReadOnlyFlag(isReadOnly),
                     }}></Factory>
                 }
               </ScrollableArea>

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -48,7 +48,7 @@ function Factory(args: {
   switch (args.q_type) {
     case 'SINGLE_SELECT':
     case 'MULTI_SELECT':
-      return <Select step={args.step as ChoiceQuestion} onChange={args.onChange} />
+      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'SLIDER':
     case 'LIKERT':

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -72,7 +72,7 @@ function Factory(args: {
       )
 
     case 'TIME':
-      return <Time step={args.step as TimeQuestion} onChange={args.onChange} />
+      return <Time step={args.step as TimeQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'YEAR':
       return <Year step={args.step as YearQuestion} onChange={args.onChange} />

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -37,6 +37,19 @@ const StyledSimpleTextInput = styled(SimpleTextInput)(({theme}) => ({
   '& input': {width: '100%'},
 }))
 
+function ReadOnlyFactory(args: {step: Step; q_type: QuestionTypeKey}) {
+  switch (args.q_type) {
+    case 'INSTRUCTION':
+    case 'COMPLETION':
+    case 'OVERVIEW':
+      return <></>  // instruction steps (of which completion and overview are subclasses) do not return any "score"
+
+    default:
+      // TODO: syoung 10/11/2023 Add read-only view for all questions (DHP-1095)
+      return <>TODO: {args.q_type} read-only view not implemented</>
+  }
+}
+
 function Factory(args: {step: Step; onChange: (step: Step) => void; q_type: QuestionTypeKey}) {
   switch (args.q_type) {
     case 'SINGLE_SELECT': {
@@ -131,16 +144,23 @@ const QuestionEditRhs: FunctionComponent<QuestionEditProps> = ({step, onChange, 
           </Box>
         )}
         <Box sx={{padding: isDynamic ? theme.spacing(3) : 0}}>
-          <Factory
-            {...{
-              step: {...step},
-              onChange: onChange,
-              q_type: getQuestionId(step),
-            }}
-            // TODO: Year and Time are partially controlled, so use a key to
-            // re-render the entire component when the step is changed.
-            // Consider making these components fully controlled instead.
-            key={step.identifier}></Factory>
+          { isReadOnly 
+            ? (<ReadOnlyFactory 
+              {...{
+                step: {...step},
+                q_type: getQuestionId(step),
+              }} key={step.identifier}></ReadOnlyFactory>)
+            : (<Factory
+              {...{
+                step: {...step},
+                onChange: onChange,
+                q_type: getQuestionId(step),
+              }}
+              // TODO: hallieswan 10/11/2023 Year and Time are partially controlled, so use a key to
+              // re-render the entire component when the step is changed. Consider making these 
+              // components fully controlled instead.
+              key={step.identifier}></Factory>)
+          }
         </Box>
       </div>
       {children}

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -52,7 +52,7 @@ function Factory(args: {
 
     case 'SLIDER':
     case 'LIKERT':
-      return <Scale step={args.step as ScaleQuestion} onChange={args.onChange} />
+      return <Scale step={args.step as ScaleQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'NUMERIC':
       return <Numeric step={args.step as ScaleQuestion} onChange={args.onChange} />

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -55,7 +55,7 @@ function Factory(args: {
       return <Scale step={args.step as ScaleQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'NUMERIC':
-      return <Numeric step={args.step as ScaleQuestion} onChange={args.onChange} />
+      return <Numeric step={args.step as ScaleQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'DURATION':
       return (

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -14,7 +14,6 @@ import Select from './rhs-subcontrols/Select'
 import SurveyTitle from './rhs-subcontrols/SurveyTitle'
 import Time from './rhs-subcontrols/Time'
 import Year from './rhs-subcontrols/Year'
-import { ReadOnlyFlag, getReadOnlyFlag } from './QuestionEditPhone'
 
 const StyledContainer = styled('div')(({theme}) => ({
   width: '516px',
@@ -43,19 +42,19 @@ function Factory(args: {
   onChange: (step: Step) => void
 
   q_type: QuestionTypeKey
-  readonly_flag?: ReadOnlyFlag
+  isReadOnly: boolean
 }) {
   switch (args.q_type) {
     case 'SINGLE_SELECT':
     case 'MULTI_SELECT':
-      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Select step={args.step as ChoiceQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'SLIDER':
     case 'LIKERT':
-      return <Scale step={args.step as ScaleQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Scale step={args.step as ScaleQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'NUMERIC':
-      return <Numeric step={args.step as ScaleQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Numeric step={args.step as ScaleQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'DURATION':
       return (
@@ -72,16 +71,16 @@ function Factory(args: {
       )
 
     case 'TIME':
-      return <Time step={args.step as TimeQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Time step={args.step as TimeQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'YEAR':
-      return <Year step={args.step as YearQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
+      return <Year step={args.step as YearQuestion} isReadOnly={args.isReadOnly} onChange={args.onChange} />
 
     case 'FREE_TEXT':
       return <></>
       
     case 'OVERVIEW': {
-      if (args.readonly_flag === 'true') {
+      if (args.isReadOnly) {
         return <></>
       } else {
         return <SurveyTitle step={args.step as BaseStep} onChange={args.onChange} />
@@ -89,7 +88,7 @@ function Factory(args: {
     }
 
     case 'COMPLETION': {
-      if (args.readonly_flag === 'true') {
+      if (args.isReadOnly) {
         return <></>
       } else {
         return <Completion step={args.step as BaseStep} onChange={args.onChange} />
@@ -158,7 +157,7 @@ const QuestionEditRhs: FunctionComponent<QuestionEditProps> = ({step, onChange, 
               step: {...step},
               onChange: onChange,
               q_type: getQuestionId(step),
-              readonly_flag: getReadOnlyFlag(isReadOnly)
+              isReadOnly: isReadOnly,
             }}
             // TODO: hallieswan 10/11/2023 Year and Time are partially controlled, so use a key to
             // re-render the entire component when the step is changed. Consider making these 

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -93,9 +93,10 @@ type QuestionEditProps = {
   dependentQuestions: number[] | undefined
   onChange: (step: Step) => void
   isDynamic: boolean
+  isReadOnly: boolean
 }
 
-const QuestionEditRhs: FunctionComponent<QuestionEditProps> = ({step, onChange, children, isDynamic}) => {
+const QuestionEditRhs: FunctionComponent<QuestionEditProps> = ({step, onChange, children, isDynamic, isReadOnly}) => {
   const matchIdentifier = () => {
     const newId = `${step?.title
       .replaceAll(' ', '_')

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -123,9 +123,11 @@ const QuestionEditRhs: FunctionComponent<QuestionEditProps> = ({step, onChange, 
               $readOnly={true}
               id="q_id"
               value={step?.identifier}></StyledSimpleTextInput>
-            <StyledButton variant="text" onClick={matchIdentifier} startIcon={<GenerateId />}>
-              Match Identifier to Question
-            </StyledButton>
+            {!isReadOnly && 
+              <StyledButton variant="text" onClick={matchIdentifier} startIcon={<GenerateId />}>
+                Match Identifier to Question
+              </StyledButton>
+            }
           </Box>
         )}
         <Box sx={{padding: isDynamic ? theme.spacing(3) : 0}}>

--- a/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditRhs.tsx
@@ -75,7 +75,7 @@ function Factory(args: {
       return <Time step={args.step as TimeQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'YEAR':
-      return <Year step={args.step as YearQuestion} onChange={args.onChange} />
+      return <Year step={args.step as YearQuestion} isReadOnly={args.readonly_flag === 'true'} onChange={args.onChange} />
 
     case 'FREE_TEXT':
       return <></>

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/Completion.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/Completion.tsx
@@ -63,7 +63,7 @@ const Completion: React.FunctionComponent<{
 
         <FormControl variant="standard" fullWidth sx={{mb: 1}}>
           <StyledH1
-            area-label="title"
+            aria-label="title"
             id="title"
             data-testid="title"
             value={step.title}
@@ -74,7 +74,7 @@ const Completion: React.FunctionComponent<{
         <FormControl variant="standard" fullWidth>
           <StyledP2
             id="summary"
-            area-label="summary"
+            aria-label="summary"
             multiline={true}
             minRows={2}
             data-testid="summary"

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/Numeric.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/Numeric.tsx
@@ -45,7 +45,7 @@ const Numeric: React.FunctionComponent<{
   return (
     <StyledContainer>
       <StyledLabel
-        area-label="fieldLabel"
+        aria-label="fieldLabel"
         sx={{fontWeight: 'bold'}}
         id="fieldLabel"
         value={step.inputItem.fieldLabel}
@@ -54,7 +54,7 @@ const Numeric: React.FunctionComponent<{
       />
       <SimpleTextInput
         sx={{width: '80px'}}
-        area-label="min"
+        aria-label="min"
         disabled={step.inputItem.type === 'integer'}
         placeholder={step.inputItem.placeholder}
         onChange={e => updateStep({...step.inputItem, placeholder: e.target.value})}></SimpleTextInput>

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/Numeric.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/Numeric.tsx
@@ -35,8 +35,9 @@ const StyledLabel = styled(DisappearingInput, {
 
 const Numeric: React.FunctionComponent<{
   step: NumericQuestion | YearQuestion
+  isReadOnly?: boolean
   onChange: (step: NumericQuestion | YearQuestion) => void
-}> = ({step, onChange}) => {
+}> = ({step, isReadOnly, onChange}) => {
   const updateStep = (inputItem: InputItem) => {
     inputItem.type = step.inputItem.type
     // @ts-ignore
@@ -50,12 +51,13 @@ const Numeric: React.FunctionComponent<{
         id="fieldLabel"
         value={step.inputItem.fieldLabel}
         placeholder="Field Label"
+        readOnly={isReadOnly}
         onChange={e => updateStep({...step.inputItem, fieldLabel: e.target.value})}
       />
       <SimpleTextInput
         sx={{width: '80px'}}
         aria-label="min"
-        disabled={step.inputItem.type === 'integer'}
+        disabled={step.inputItem.type === 'integer' || isReadOnly}
         placeholder={step.inputItem.placeholder}
         onChange={e => updateStep({...step.inputItem, placeholder: e.target.value})}></SimpleTextInput>
     </StyledContainer>

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/Scale.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/Scale.tsx
@@ -135,7 +135,7 @@ const MinMaxLabel: React.FunctionComponent<{
 
   return (
     <StyledMinMaxLabel
-      area-label={CONFIG[type].label}
+      aria-label={CONFIG[type].label}
       sx={{fontWeight: 'bold'}}
       id={CONFIG[type].label}
       value={value}

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/Select.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/Select.tsx
@@ -69,10 +69,11 @@ const SelectOption: FunctionComponent<{
     isStatic?: boolean
     isSingleChoice?: boolean
     isOther?: boolean
+    isReadOnly?: boolean
   }
 }> = ({choice, onDelete, onRename, options}) => {
   const [title, setTitle] = React.useState(choice.text)
-  const {provided, isStatic, isSingleChoice} = options
+  const {provided, isStatic, isSingleChoice, isReadOnly} = options
   return (
     <Option
       {...provided?.draggableProps}
@@ -80,10 +81,11 @@ const SelectOption: FunctionComponent<{
       ref={provided?.innerRef}
       isSingleChoice={isSingleChoice}>
       <div />
-      {isStatic ? (
+      {isStatic || isReadOnly ? (
         <Typography sx={{padding: theme.spacing(0.5, 0.5)}}>{title}</Typography>
       ) : (
         <DisappearingInput
+          readOnly={isReadOnly}
           sx={{'& input': {padding: theme.spacing(0.25, 0.5), backgroundColor: '#fff'}}}
           value={title}
           onChange={e => setTitle(e.target.value)}
@@ -92,10 +94,12 @@ const SelectOption: FunctionComponent<{
       )}
 
       <div>
-        {provided !== undefined && <DraggableIcon />}
+        {provided !== undefined && !isReadOnly && <DraggableIcon />}
+        {!isReadOnly && (
         <IconButton onClick={() => onDelete(title)} sx={{padding: 0, marginLeft: '4px'}} title="delete">
           <ClearIcon fontSize="small" />
-        </IconButton>
+        </IconButton> 
+        )}
       </div>
     </Option>
   )
@@ -103,9 +107,9 @@ const SelectOption: FunctionComponent<{
 
 const Select: React.FunctionComponent<{
   step: ChoiceQuestion
-
+  isReadOnly?: boolean
   onChange: (step: ChoiceQuestion) => void
-}> = ({step: stepData, onChange}) => {
+}> = ({step: stepData, isReadOnly, onChange}) => {
   // const stepData = step as ChoiceQuestion
   const onDragEnd = (result: DropResult) => {
     if (!stepData.choices) {
@@ -206,7 +210,7 @@ const Select: React.FunctionComponent<{
               {[...stepData.choices!].slice(0, getIndexOfTheLastRealQuestion() + 1).map((choice, index) => (
                 <Draggable
                   draggableId={choice.value?.toString() || ''}
-                  isDragDisabled={false}
+                  isDragDisabled={isReadOnly}
                   index={index}
                   key={choice.value?.toString()}>
                   {provided => (
@@ -214,6 +218,7 @@ const Select: React.FunctionComponent<{
                       options={{
                         isSingleChoice: stepData.singleChoice,
                         provided,
+                        isReadOnly: isReadOnly,
                       }}
                       onRename={qText => renameOption(qText, index)}
                       choice={choice}

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/SurveyTitle.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/SurveyTitle.tsx
@@ -17,10 +17,11 @@ const TitleIcon = styled('div', {label: 'TitleIcon'})(({theme}) => ({
 
 type SurveyTitleProps = {
   step: BaseStep
+  isReadOnly?: boolean
   onChange: (s: BaseStep) => void
 }
 
-const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, onChange}) => {
+const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, isReadOnly, onChange}) => {
   /*{
 	"type": "assessment",
 	"identifier": "foo",
@@ -52,6 +53,7 @@ const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, onChange}
           aria-label="title"
           sx={{fontWeight: 'bold'}}
           id="title"
+          readOnly={isReadOnly}
           value={step.title}
           placeholder="Title"
           onChange={e => onChange({...step, title: e.target.value})}
@@ -64,7 +66,8 @@ const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, onChange}
           multiline={true}
           minRows={4}
           sx={{fontSize: '12px'}}
-          placeholder={step.detail}
+          placeholder='Summary'
+          readOnly={isReadOnly}
           value={step.detail}
           onChange={e => onChange({...step, detail: e.target.value})}
         />

--- a/src/components/surveys/survey-design/question-edit/phone-subcontrols/SurveyTitle.tsx
+++ b/src/components/surveys/survey-design/question-edit/phone-subcontrols/SurveyTitle.tsx
@@ -49,7 +49,7 @@ const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, onChange}
       </TitleIcon>
       <FormControl variant="standard" fullWidth sx={{mb: 0}}>
         <DisappearingInput
-          area-label="title"
+          aria-label="title"
           sx={{fontWeight: 'bold'}}
           id="title"
           value={step.title}
@@ -60,7 +60,7 @@ const SurveyTitle: React.FunctionComponent<SurveyTitleProps> = ({step, onChange}
       <FormControl variant="standard" fullWidth>
         <DisappearingInput
           id="summary"
-          area-label="summary"
+          aria-label="summary"
           multiline={true}
           minRows={4}
           sx={{fontSize: '12px'}}

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Numeric.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Numeric.tsx
@@ -9,11 +9,12 @@ import React, {ChangeEvent} from 'react'
 const ValueSelector: React.FunctionComponent<{
   value?: number
   isDisabled?: boolean
+  isReadOnly?: boolean
   hasError?: boolean
   type: 'MIN' | 'MAX'
 
   onChange: (value: number) => void
-}> = ({value, type, isDisabled, hasError, onChange}) => {
+}> = ({value, type, isDisabled, isReadOnly, hasError, onChange}) => {
   const CONFIG = {
     MIN: {
       label: 'Min Value',
@@ -39,6 +40,7 @@ const ValueSelector: React.FunctionComponent<{
           disabled={isDisabled}
           //@ts-ignore
           onChange={(e: ChangeEvent<any>) => {
+            if (isReadOnly) return
             onChange(parseInt(e.target.value))
           }}
         />
@@ -49,8 +51,9 @@ const ValueSelector: React.FunctionComponent<{
 
 const Numeric: React.FunctionComponent<{
   step: NumericQuestion
+  isReadOnly?: boolean
   onChange: (step: NumericQuestion) => void
-}> = ({step, onChange}) => {
+}> = ({step, isReadOnly, onChange}) => {
   const [rangeDisabled, setRangeDisabled] = React.useState(
     step.inputItem.formatOptions?.minimumValue === undefined && step.inputItem.formatOptions?.maximumValue === undefined
   )
@@ -77,6 +80,7 @@ const Numeric: React.FunctionComponent<{
   }, [range])
 
   const changeRangeDisabled = (val: boolean) => {
+    if (isReadOnly) return
     setRangeDisabled(val)
     if (val) {
       setRange(undefined)
@@ -101,6 +105,7 @@ const Numeric: React.FunctionComponent<{
         <ValueSelector
           type="MIN"
           isDisabled={rangeDisabled}
+          isReadOnly={isReadOnly}
           value={range?.min}
           hasError={!!error}
           onChange={num => {
@@ -117,6 +122,7 @@ const Numeric: React.FunctionComponent<{
         <ValueSelector
           type="MAX"
           isDisabled={rangeDisabled}
+          isReadOnly={isReadOnly}
           value={range?.max}
           onChange={num => {
             const isValid = validate({min: range?.min, max: num})

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Scale.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Scale.tsx
@@ -25,8 +25,9 @@ const ValueSelector: React.FunctionComponent<{
   scaleType: 'likert' | 'slider'
   type: 'MIN' | 'MAX'
   gtValue?: number
+  isReadOnly?: boolean
   onChange: (value: number) => void
-}> = ({value, scaleType, type, gtValue = -1, onChange}) => {
+}> = ({value, scaleType, type, gtValue = -1, isReadOnly, onChange}) => {
   const CONFIG = {
     MIN: {
       label: 'Min Value',
@@ -46,6 +47,7 @@ const ValueSelector: React.FunctionComponent<{
         {CONFIG[type].label}
       </StyledLabel14>
       <StyledDropDown
+        readOnly={isReadOnly}
         labelId={CONFIG[type].labelId}
         value={value}
         height="42px"
@@ -70,9 +72,11 @@ const ValueSelector: React.FunctionComponent<{
 
 const Scale: React.FunctionComponent<{
   step: ScaleQuestion
+  isReadOnly?: boolean
   onChange: (step: Step) => void
-}> = ({step, onChange}) => {
+}> = ({step, isReadOnly, onChange}) => {
   const onUpdateFormat = (fm: FormatOptionsInteger) => {
+    if (isReadOnly) return
     const inputItem = {...step.inputItem, formatOptions: fm}
     onChange({...step, inputItem})
   }
@@ -83,6 +87,7 @@ const Scale: React.FunctionComponent<{
           display: 'flex',
         }}>
         <ValueSelector
+          isReadOnly={isReadOnly}
           type="MIN"
           scaleType={step.uiHint}
           value={step.inputItem.formatOptions.minimumValue || 0}
@@ -94,6 +99,7 @@ const Scale: React.FunctionComponent<{
           }
         />
         <ValueSelector
+          isReadOnly={isReadOnly}
           type="MAX"
           scaleType={step.uiHint}
           gtValue={1}

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
@@ -135,8 +135,9 @@ function generateValue(choice: ChoiceQuestionChoice, setTo?: number) {
 
 const Select: React.FunctionComponent<{
   step: ChoiceQuestion
+  isReadOnly?: boolean
   onChange: (step: ChoiceQuestion) => void
-}> = ({step, onChange}) => {
+}> = ({step, isReadOnly, onChange}) => {
   const selectTypeOptions: QuestionTypeKey[] = ['MULTI_SELECT', 'SINGLE_SELECT']
   const [isTypeConversionWarning, setIsTypeConversionWarning] = React.useState(false)
   const answerDataTypeOptions: QuestionDataType[] = ['integer', 'string']
@@ -201,6 +202,7 @@ const Select: React.FunctionComponent<{
         <StyledLabel14 mb={0.5}>Question Type:</StyledLabel14>
 
         <StyledDropDown
+          readOnly={isReadOnly}
           value={step.singleChoice ? 'SINGLE_SELECT' : 'MULTI_SELECT'}
           width="200px"
           height="40px"
@@ -223,6 +225,7 @@ const Select: React.FunctionComponent<{
         <StyledLabel14 mb={0.5}>Set Response Value Pairing:</StyledLabel14>
 
         <StyledDropDown
+          readOnly={isReadOnly}
           value={step.baseType}
           height="48px"
           width="130px"
@@ -243,7 +246,7 @@ const Select: React.FunctionComponent<{
       <PairingTableHeading answerDataType={step.baseType} isSingleChoice={step.singleChoice} />
 
       <Box sx={{backgroundColor: '#fff', padding: theme.spacing(2, 1.5)}}>
-        {step.baseType === 'string' && (
+        {step.baseType === 'string' && !isReadOnly && (
           <Button
             variant="text"
             startIcon={<GenerateId />}

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.test.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.test.tsx
@@ -56,9 +56,6 @@ test('renders the component with min and max', () => {
 
   expect(min).not.toHaveClass('Mui-disabled')
   expect(max).not.toHaveClass('Mui-disabled')
-  expect(screen.getByRole('radio', {name: /allow any time value/i})).toHaveProperty('checked', true)
-  expect(screen.getByRole('radio', {name: /allow only time in the future/i})).toHaveProperty('checked', false)
-  expect(screen.getByRole('radio', {name: /allow only time in the past/i})).toHaveProperty('checked', false)
 })
 
 test('updates values', async () => {
@@ -92,5 +89,4 @@ test('updates values', async () => {
   expect(min).toHaveClass('Mui-disabled')
   expect(max).toHaveClass('Mui-disabled')
   expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-  expect(screen.getByRole('radio', {name: /allow only time in the past/i})).toHaveProperty('checked', true)
 }, 20_000)

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.tsx
@@ -36,10 +36,11 @@ import React from 'react'
 const ValueSelector: React.FunctionComponent<{
   value: string | undefined
   isDisabled: boolean
+  isReadOnly?: boolean
   type: 'MIN' | 'MAX'
 
   onChange: (value: string) => void
-}> = ({value, type, isDisabled, onChange}) => {
+}> = ({value, type, isDisabled, isReadOnly, onChange}) => {
   const CONFIG = {
     MIN: {
       label: 'Min Value',
@@ -58,6 +59,7 @@ const ValueSelector: React.FunctionComponent<{
       </StyledLabel14>
 
       <StyledDropDown
+        readOnly={isReadOnly}
         labelId={CONFIG[type].labelId}
         value={value || ''}
         height="42px"
@@ -97,8 +99,9 @@ function getLimit(fo?: FormatOptionsTime): LimitType {
 // Consider making this components fully controlled instead.
 const Time: React.FunctionComponent<{
   step: TimeQuestion
+  isReadOnly?: boolean
   onChange: (step: TimeQuestion) => void
-}> = ({step, onChange}) => {
+}> = ({step, isReadOnly, onChange}) => {
   const [rangeDisabled, setRangeDisabled] = React.useState(
     step.inputItem.formatOptions?.minimumValue === undefined && step.inputItem.formatOptions?.maximumValue === undefined
   )
@@ -126,6 +129,7 @@ const Time: React.FunctionComponent<{
   }, [range])
 
   const changeRangeDisabled = (val: boolean) => {
+    if (isReadOnly) return
     setRangeDisabled(val)
     if (val) {
       setRange(undefined)
@@ -151,6 +155,7 @@ const Time: React.FunctionComponent<{
         <ValueSelector
           type="MIN"
           isDisabled={rangeDisabled}
+          isReadOnly={isReadOnly}
           value={range?.min}
           onChange={num => {
             const isValid = validate({min: num, max: range?.min})
@@ -166,6 +171,7 @@ const Time: React.FunctionComponent<{
         <ValueSelector
           type="MAX"
           isDisabled={rangeDisabled}
+          isReadOnly={isReadOnly}
           value={range?.max}
           onChange={num => {
             const isValid = validate({min: range?.min, max: num})

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Time.tsx
@@ -18,19 +18,20 @@ import {theme} from '@style/theme'
 import {FormatOptionsTime, TimeQuestion} from '@typedefs/surveys'
 import React from 'react'
 
-const Labels = styled('div', {label: 'labels'})(({theme}) => ({
-  backgroundColor: '#fff',
-  padding: theme.spacing(2, 1.5),
-  marginTop: theme.spacing(2),
+// TODO: syoung 10/11/2023 Revisit this design later - it doesn't really make sense to allow time questions to constrain to future/past.
+// const Labels = styled('div', {label: 'labels'})(({theme}) => ({
+//   backgroundColor: '#fff',
+//   padding: theme.spacing(2, 1.5),
+//   marginTop: theme.spacing(2),
 
-  '& > label': {
-    marginBottom: theme.spacing(0.5),
-    '& span': {
-      width: '130px',
-      display: 'inline-block',
-    },
-  },
-}))
+//   '& > label': {
+//     marginBottom: theme.spacing(0.5),
+//     '& span': {
+//       width: '130px',
+//       display: 'inline-block',
+//     },
+//   },
+// }))
 
 const ValueSelector: React.FunctionComponent<{
   value: string | undefined
@@ -179,7 +180,7 @@ const Time: React.FunctionComponent<{
         />
       </Box>
       {error && <AlertWithTextWrapper text={error}></AlertWithTextWrapper>}
-      <Labels>
+      {/* <Labels>
         <RadioGroup
           id="exclude"
           value={exclude}
@@ -210,7 +211,7 @@ const Time: React.FunctionComponent<{
             label={'Allow only time in the past'}
           />
         </RadioGroup>
-      </Labels>
+      </Labels> */}
       <Typography variant="body1" margin={(theme.spacing(3), 'auto', 'auto', theme.spacing(3))}>
         *The actual UI for this question will default to the system's OS interface.{' '}
       </Typography>

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Year.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Year.tsx
@@ -15,8 +15,9 @@ export const ErrorMessages = {
 // Consider making this components fully controlled instead.
 const Year: React.FunctionComponent<{
   step: YearQuestion
+  isReadOnly?: boolean
   onChange: (step: YearQuestion) => void
-}> = ({step: initialStep, onChange: onValidChange}) => {
+}> = ({step: initialStep, isReadOnly, onChange: onValidChange}) => {
   const [minimumYear, setMinimumYear] = React.useState<number | undefined>(
     initialStep.inputItem.formatOptions?.minimumYear
   )
@@ -61,6 +62,7 @@ const Year: React.FunctionComponent<{
     allowPast?: boolean,
     allowFuture?: boolean
   ) => {
+    if (isReadOnly) return
     const error = validate(minimumYear, maximumYear, allowPast, allowFuture)
     setError(error)
 
@@ -84,6 +86,7 @@ const Year: React.FunctionComponent<{
           allowValue={allowPast}
           yearValue={minimumYear}
           hasError={error === 'RANGE' || error === 'NO_PAST_YEARS'}
+          isReadOnly={isReadOnly}
           onChange={(allowPast, minimumYear) => {
             setMinimumYear(minimumYear)
             setAllowPast(allowPast)
@@ -95,6 +98,7 @@ const Year: React.FunctionComponent<{
           allowValue={allowFuture}
           yearValue={maximumYear}
           hasError={error === 'RANGE' || error === 'NO_FUTURE_YEARS'}
+          isReadOnly={isReadOnly}
           onChange={(allowFuture, maximumYear) => {
             setMaximumYear(maximumYear)
             setAllowFuture(allowFuture)

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/YearRadioGroup.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/YearRadioGroup.tsx
@@ -39,6 +39,7 @@ type YearRadioGroupProps = {
   allowValue: boolean | undefined
   yearValue: number | undefined
   hasError: boolean
+  isReadOnly?: boolean
   onChange: (allowValue: boolean | undefined, yearValue: number | undefined) => void
 }
 
@@ -47,6 +48,7 @@ const YearRadioGroup: React.FunctionComponent<YearRadioGroupProps> = ({
   allowValue,
   yearValue,
   hasError,
+  isReadOnly,
   onChange,
 }) => {
   const id = `${type}YearGroup`
@@ -74,6 +76,7 @@ const YearRadioGroup: React.FunctionComponent<YearRadioGroupProps> = ({
         type="number"
         disabled={yearValue === undefined}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+          if (isReadOnly) return
           onChange(
             yearFormatToAllowValue(yearFormat),
             setYearValue(yearFormat, parseInt(e.target.value) || defaultYearValue)
@@ -92,6 +95,7 @@ const YearRadioGroup: React.FunctionComponent<YearRadioGroupProps> = ({
           id={`${type}YearFormat`}
           value={yearFormat}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            if (isReadOnly) return
             const newYearFormat = e.target.value as YearFormatType
             onChange(yearFormatToAllowValue(newYearFormat), setYearValue(newYearFormat, yearValue || defaultYearValue))
           }}>

--- a/src/components/widgets/ReadOnlyBanner.tsx
+++ b/src/components/widgets/ReadOnlyBanner.tsx
@@ -1,9 +1,9 @@
 import { Box } from '@mui/material'
 import { theme } from '@style/theme'
 import ErrorTwoToneIcon from '@mui/icons-material/ErrorTwoTone'
-import React, {FunctionComponent} from 'react'
+import React from 'react'
 
-const ReadOnlyBanner: React.FunctionComponent<{label: String}> = ({
+const ReadOnlyBanner: React.FunctionComponent<{label: string}> = ({
   label,
 }) => <Box
   sx={{

--- a/src/components/widgets/ReadOnlyBanner.tsx
+++ b/src/components/widgets/ReadOnlyBanner.tsx
@@ -1,0 +1,21 @@
+import { Box } from '@mui/material'
+import { theme } from '@style/theme'
+import ErrorTwoToneIcon from '@mui/icons-material/ErrorTwoTone'
+import React, {FunctionComponent} from 'react'
+
+const ReadOnlyBanner: React.FunctionComponent<{label: String}> = ({
+  label,
+}) => <Box
+  sx={{
+    backgroundColor: 'rgba(255, 168, 37, 0.15)',
+    textAlign: 'left',
+    fontSize: '16px',
+
+    display: 'flex',
+    padding: theme.spacing(1, 8),
+  }}>
+  <ErrorTwoToneIcon sx={{ color: '#FFA825' }}></ErrorTwoToneIcon>&nbsp;&nbsp;This {label} is in read-only mode and
+  can not be edited.
+</Box>
+
+export default ReadOnlyBanner

--- a/src/services/assessmentHooks.ts
+++ b/src/services/assessmentHooks.ts
@@ -183,6 +183,9 @@ export const useUpdateSurveyAssessment = () => {
 
       case 'UPDATE':
         console.log('updating', assessment)
+        if (assessment.isReadOnly) {
+          throw Error('Cannot update a published assessment')
+        }
         return AssessmentService.updateSurveyAssessment(appId, assessment, token!)
         
       case 'CREATE':


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1095
https://sagebionetworks.jira.com/browse/DHP-1111

The `phase == 'published'` flag does not block editing the `Assessment`, only the `AssessmentConfig`, so it became a really poor user experience to view a published survey. This is not the cleanest UI/UX for handling this and it meant going through each component and a lot of code that looks *very* similar.

There are a number of "icky bits" that it would be nice to clean up "someday", most especially:

1. I tried to follow the existing naming convention used for studies of `isReadOnly` instead of the React naming convention of `readOnly`.
2. The React `readOnly` flag isn't honored on all controls (not sure why) so often I ended up using `if (isReadOnly) return` to exit the update functions early. This seemed to be the only way to block text fields, radio buttons, and checkboxes.
3. The `Factory` function that is copy/pasted everywhere should probably be a React component. 
4. It would be really nice to have some kind of a global access to the assessment values beyond `guid` so that I can use that throughout the survey editor.
5. I did not add tests for any of these changes. Since most of them block by blocking the model from updating, I'm not entirely certain how to add tests for that.

Finally, I didn't fix the "Branching Logic". Couldn't figure out how to propagate the `isReadOnly` ivar. Opened https://sagebionetworks.jira.com/browse/DHP-1114 to track.