### PR TITLE
Fix survey bugs discovered during testing

### DIFF
--- a/src/components/surveys/survey-design/left-panel/QuestionConfigs.tsx
+++ b/src/components/surveys/survey-design/left-panel/QuestionConfigs.tsx
@@ -79,6 +79,7 @@ const QUESTIONS = new Map<QuestionTypeKey, {img: React.ReactElement; title: stri
         inputItem: {
           type: 'string',
           placeholder: '(Maximum 250 characters)',
+          characterLimit: 250,
         },
       },
     },
@@ -209,9 +210,6 @@ const QUESTIONS = new Map<QuestionTypeKey, {img: React.ReactElement; title: stri
         title: 'New Question',
         inputItem: {
           type: 'time',
-          formatOptions: {
-            allowFuture: false,
-          },
         },
       },
     },

--- a/src/types/surveys.ts
+++ b/src/types/surveys.ts
@@ -96,11 +96,13 @@ export interface ChoiceQuestion extends Question {
     fieldLabel?: string // no column
   }
 }
+
 export interface MultipleInputQuestion extends Question {
   optional: boolean
   inputItems: InputItem[]
   skipCheckbox?: Skip
 }
+
 export interface ScaleQuestion extends Question {
   uiHint: 'likert' | 'slider'
   inputItem: InputItem & {
@@ -108,6 +110,7 @@ export interface ScaleQuestion extends Question {
     formatOptions: FormatOptionsInteger
   }
 }
+
 export interface DurationQuestion extends Question {
   inputItem: InputItem & {
     type: 'duration'
@@ -130,6 +133,13 @@ export interface NumericQuestion extends Question {
   }
 }
 
+export interface FreeTextQuestion extends Question {
+  inputItem: InputItem & {
+    type: 'string'
+    characterLimit?: number
+  }
+}
+
 export interface YearQuestion extends Question {
   inputItem: InputItem & {
     type: 'year'
@@ -147,9 +157,7 @@ export interface BaseStep {
     | 'unknown'
     | 'instruction'
     | 'simpleQuestion'
-    //| 'multipleInputQuestion'
     | 'choiceQuestion'
-  //   | 'comboBoxQuestion' //otherInputItem
   title: string //Instruction Step 1',
   subtitle?: string
   detail?: string //Here are the details for this instruction.',


### PR DESCRIPTION
1. “Free Text” wasn’t setting the character limit
2. Time questions were setting `allowFuture = false` by default which doesn’t make sense