### PR TITLE
Simplify settings for the surveys

### DIFF
--- a/src/components/surveys/survey-design/IntroInfo.test.tsx
+++ b/src/components/surveys/survey-design/IntroInfo.test.tsx
@@ -66,22 +66,14 @@ async function triggerSave(isNew?: boolean) {
   })
 }
 
-function getSurveyQuestionSettings() {
-  return [
-    screen.getByRole('radio', {name: /allow partcipants to skip/i}),
-    screen.getByRole('radio', {name: /make all survey questions required/i}),
-    screen.getByRole('radio', {name: /customize each/i}),
-  ]
-}
-
 function getPauseMenuSettings() {
-  const review = screen.getByRole('checkbox', {name: /review instructions/i})
+  // const review = screen.getByRole('checkbox', {name: /review instructions/i})
   const skip = screen.getByRole('checkbox', {name: /skip this activity/i})
 
   //save continue
   const save = screen.getByRole('radio', {name: /save & continue later /i})
   const exit = screen.getByRole('radio', {name: /exit without saving /i})
-  return {review, skip, save, exit}
+  return {skip, save, exit}
 }
 
 describe('<IntroInfo/>', () => {
@@ -115,19 +107,16 @@ describe('<IntroInfo/>', () => {
     test('should allow to skip and cusomize each quesiton by default', () => {
       //default is:
       // shouldHideActions: [],
-      // webConfig: {
-      //   skipOption: 'CUSTOMIZE',
-      // }
       //
       renderComponent(undefined, true)
-      const radios = getSurveyQuestionSettings()
 
+      const navigateSkipCheck = screen.getByRole('checkbox', {
+        name: /make all survey questions required/i,
+      })
       const navigateBackCheck = screen.getByRole('checkbox', {
         name: /allow participants to navigate/i,
       })
-      expect(radios[0]).not.toBeChecked()
-      expect(radios[1]).not.toBeChecked()
-      expect(radios[2]).toBeChecked()
+      expect(navigateSkipCheck).not.toBeChecked()
       expect(navigateBackCheck).toBeChecked()
     })
 
@@ -170,18 +159,17 @@ describe('<IntroInfo/>', () => {
 
   test('should display and set Survey Question Settings', async () => {
     renderComponent(surveyConfig)
-    const radios = getSurveyQuestionSettings()
-
+    const navigateSkipCheck = screen.getByRole('checkbox', {
+      name: /make all survey questions required/i,
+    })
     const navigateBackCheck = screen.getByRole('checkbox', {
       name: /allow participants to navigate/i,
     })
-    expect(radios[0]).not.toBeChecked()
-    expect(radios[1]).toBeChecked()
-    expect(radios[2]).not.toBeChecked()
+    expect(navigateSkipCheck).toBeChecked()
     expect(navigateBackCheck).not.toBeChecked()
     await waitFor(() => {
-      radios[0].focus()
-      radios[0].click()
+      navigateSkipCheck.focus()
+      navigateSkipCheck.click()
       navigateBackCheck.focus()
       navigateBackCheck.click()
     })
@@ -196,25 +184,24 @@ describe('<IntroInfo/>', () => {
   /* 
   default for interruptionHandling: {
       canResume: true,
-      reviewIdentifier: 'beginning',
-      canSkip: true,
+      reviewIdentifier: undefined,
+      canSkip: false,
       canSaveForLater: true,
     },*/
 
   test('should display default "Pause Menu" settings if info is not provided ', () => {
     renderComponent(undefined)
 
-    const {review, skip, save, exit} = getPauseMenuSettings()
-    expect(review).toBeChecked()
-    expect(skip).toBeChecked()
+    const {skip, save, exit} = getPauseMenuSettings()
+    expect(skip).not.toBeChecked()
     expect(save).toBeChecked()
     expect(exit).not.toBeChecked()
   })
+
   test('should display and set "Pause Menu" settings ', () => {
     renderComponent(surveyConfig)
 
-    const {review, skip, save, exit} = getPauseMenuSettings()
-    expect(review).not.toBeChecked()
+    const {skip, save, exit} = getPauseMenuSettings()
     expect(skip).not.toBeChecked()
     expect(save).not.toBeChecked()
     expect(exit).toBeChecked()

--- a/src/components/surveys/survey-design/IntroInfo.tsx
+++ b/src/components/surveys/survey-design/IntroInfo.tsx
@@ -364,23 +364,6 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps & RouteComponentProps> =
               </Typography>
             }
           />
-
-          {/* <FormControlLabel
-            value={interruptionHandling.reviewIdentifier}
-            sx={{mt: theme.spacing(1.5)}}
-            control={
-              <Checkbox
-                checked={interruptionHandling.reviewIdentifier !== undefined}
-                onChange={e => updateInterruptonHandling('reviewIdentifier', e.target.checked)}
-              />
-            }
-            label={
-              <Typography sx={{fontSize: '14px'}}>
-                <strong>Review Instructions</strong> <br /> Displays the Title Page message to participant for review.
-              </Typography>
-            }
-          /> */}
-
           <FormControlLabel
             sx={{mt: theme.spacing(1.5), fontSize: '14px'}}
             control={

--- a/src/components/surveys/survey-design/SurveyDesign.tsx
+++ b/src/components/surveys/survey-design/SurveyDesign.tsx
@@ -430,7 +430,7 @@ const SurveyDesign: FunctionComponent<SurveyDesignProps> = () => {
                   <QuestionEditPhone
                     isReadOnly={isReadOnly}
                     isDynamic={isDynamicStep()}
-                    globalSkipConfiguration={survey!.config.webConfig?.skipOption || 'CUSTOMIZE'}
+                    globalHideActions={survey!.config.shouldHideActions ?? []}
                     onChange={(step: Step) => {
                       updateCurrentStep(step)
                     }}

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.test.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.test.tsx
@@ -1,22 +1,23 @@
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {Step, WebUISkipOptions} from '@typedefs/surveys'
+import {ActionButtonName, Step} from '@typedefs/surveys'
 import surveyQuestions from '__test_utils/mocks/surveyQuestions'
 import QuestionEditPhone from './QuestionEditPhone'
 
 const onChange = jest.fn()
 
-const renderComponent = (isDynamic: boolean, skipConfig: WebUISkipOptions, step: Step, progress: number) => {
+const renderComponent = (isDynamic: boolean, skipConfig: ActionButtonName[], step: Step, progress: number) => {
   const component = render(
     <QuestionEditPhone
       isDynamic={isDynamic}
-      globalSkipConfiguration={skipConfig}
+      globalHideActions={skipConfig}
       onChange={(step: Step) => {
         onChange(step)
-      }}
+      } }
       step={step}
-      completionProgress={progress}
-    />
+      completionProgress={progress} 
+      isReadOnly={false}    
+      />
   )
   const user = userEvent.setup()
   return {user, component}
@@ -24,7 +25,7 @@ const renderComponent = (isDynamic: boolean, skipConfig: WebUISkipOptions, step:
 
 describe('QuestionEditPhone', () => {
   it('should render with correct buttons for static questions', () => {
-    renderComponent(false, 'CUSTOMIZE', surveyQuestions[0], 10)
+    renderComponent(false, [], surveyQuestions[0], 10)
     expect(surveyQuestions[0].type).toBe('overview')
     expect(screen.queryByRole('button', {name: /make required/i})).not.toBeInTheDocument()
     expect(screen.queryByRole('button', {name: /allow skip/i})).not.toBeInTheDocument()
@@ -34,7 +35,7 @@ describe('QuestionEditPhone', () => {
   })
 
   it('should render with correct buttons for dynamic not choice questions', () => {
-    renderComponent(true, 'CUSTOMIZE', surveyQuestions[2], 10)
+    renderComponent(true, [], surveyQuestions[2], 10)
     expect(surveyQuestions[2].type).toBe('simpleQuestion')
     expect(screen.queryByRole('button', {name: /make required/i})).toBeInTheDocument()
     expect(screen.queryByRole('button', {name: /allow skip/i})).toBeInTheDocument()
@@ -44,7 +45,7 @@ describe('QuestionEditPhone', () => {
   })
 
   it('should render with correct buttons for choice questions', () => {
-    renderComponent(true, 'CUSTOMIZE', surveyQuestions[1], 10)
+    renderComponent(true, [], surveyQuestions[1], 10)
     expect(surveyQuestions[1].type).toBe('choiceQuestion')
     expect(screen.queryByRole('button', {name: /make required/i})).toBeInTheDocument()
     expect(screen.queryByRole('button', {name: /allow skip/i})).toBeInTheDocument()
@@ -53,16 +54,9 @@ describe('QuestionEditPhone', () => {
     expect(screen.queryByRole('button', {name: /sort reverse/i})).toBeInTheDocument()
   })
 })
-it('should render with correct buttons with config set to SKIP', () => {
-  renderComponent(true, 'SKIP', surveyQuestions[1], 10)
-
-  expect(screen.queryByRole('button', {name: /make required/i})).not.toBeInTheDocument()
-  expect(screen.queryByRole('button', {name: /allow skip/i})).not.toBeInTheDocument()
-  expect(screen.queryByText(/Skip question/i)).toBeInTheDocument()
-})
 
 it('should render with correct buttons with config set to MAKE ALL REQUIRED ', () => {
-  renderComponent(true, 'NO_SKIP', surveyQuestions[1], 10)
+  renderComponent(true, ['skip', 'goBackward'], surveyQuestions[1], 10)
 
   expect(screen.queryByRole('button', {name: /make required/i})).not.toBeInTheDocument()
   expect(screen.queryByRole('button', {name: /allow skip/i})).not.toBeInTheDocument()

--- a/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
+++ b/src/components/surveys/survey-design/question-edit/QuestionEditPhone.tsx
@@ -4,6 +4,7 @@ import {DisappearingInput} from '@components/surveys/widgets/SharedStyled'
 import {Box, styled, Typography, TypographyProps} from '@mui/material'
 import {latoFont, theme} from '@style/theme'
 import {
+  ActionButtonName,
   BaseStep,
   ChoiceQuestion,
   ChoiceQuestionChoice,
@@ -11,7 +12,6 @@ import {
   Question,
   ScaleQuestion,
   Step,
-  WebUISkipOptions,
 } from '@typedefs/surveys'
 import {FunctionComponent} from 'react'
 import {getQuestionId, QuestionTypeKey} from '../left-panel/QuestionConfigs'
@@ -93,7 +93,7 @@ type QuestionEditProps = {
   isReadOnly: boolean
   isDynamic: boolean
   step?: Step
-  globalSkipConfiguration: WebUISkipOptions
+  globalHideActions: ActionButtonName[]
   completionProgress: number
 
   onChange: (step: Step) => void
@@ -169,7 +169,7 @@ const PhoneProgressLine: FunctionComponent<{
 
 const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
   step,
-  globalSkipConfiguration,
+  globalHideActions,
   completionProgress,
   isDynamic,
   isReadOnly,
@@ -179,7 +179,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
 
   const shouldShowSkipButton = (): boolean => {
     //show skip button if not required in global config and is not hidden on local config
-    return globalSkipConfiguration !== 'NO_SKIP' && !step!.shouldHideActions?.includes('skip')
+    return !globalHideActions.includes('skip') && !step!.shouldHideActions?.includes('skip')
   }
 
   const sortSelectChoices = (choiceQ: ChoiceQuestion, direction: 1 | -1): ChoiceQuestionChoice[] => {
@@ -277,7 +277,7 @@ const QuestionEditPhone: FunctionComponent<QuestionEditProps> = ({
             </Box>
           </PhoneDisplay>
 
-          {globalSkipConfiguration === 'CUSTOMIZE' && isDynamic && !isReadOnly && (
+          {!globalHideActions.includes('skip') && isDynamic && !isReadOnly && (
             <RequiredToggle
               shouldHideActionsArray={step.shouldHideActions || []}
               onChange={shouldHideActions =>

--- a/src/types/surveys.ts
+++ b/src/types/surveys.ts
@@ -183,7 +183,6 @@ export type ActionButtonName =
   | 'pause'
   | 'reviewInstructions'
 
-export type WebUISkipOptions = 'SKIP' | 'NO_SKIP' | 'CUSTOMIZE'
 export type InterruptionHandlingType = {
   canResume: boolean
   reviewIdentifier?: 'beginning'
@@ -191,7 +190,6 @@ export type InterruptionHandlingType = {
   canSaveForLater: boolean
 }
 export type SurveyConfig = {
-  webConfig?: {skipOption?: WebUISkipOptions}
   type: string //'assessment',
   interruptionHandling?: InterruptionHandlingType
   identifier: string //'foo',


### PR DESCRIPTION
- Simplify the “skip rules” for surveys to include a global checkbox for making all questions required.
- Hide the “Review Instructions” navigation because it makes no sense.
- Default to *not* allowing participants to skip surveys
- Fix Question toggle visibility
- Fix “Save Changes” functionality to indicate that changes have been made to settings
- Add “Summary” text field at the bottom of the settings page

https://sagebionetworks.jira.com/browse/DHP-1132
https://sagebionetworks.jira.com/browse/DHP-1133