### PR TITLE
Making branching logic read-only in production

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,11 @@ function App() {
         {redirect && <Redirect to={redirect}></Redirect>}
         {/*  <React.StrictMode>*/}
         <FeatureToggleProvider
-          featureToggles={{[features.SURVEY_BUILDER]: true, [features.USERNAME_PASSWORD_LOGIN]: isDevelopment()}}>
+          featureToggles={{
+            [features.SURVEY_BUILDER]: true, 
+            [features.SURVEY_BRANCHING_LOGIC]: isDevelopment(),
+            [features.USERNAME_PASSWORD_LOGIN]: isDevelopment(),
+            }}>
           <Container
             id="outer"
             maxWidth="xl"

--- a/src/components/surveys/SurveyTopNav.tsx
+++ b/src/components/surveys/SurveyTopNav.tsx
@@ -136,18 +136,11 @@ type SurveyTopNavProps = {
 }
 
 const ALL_LINKS: {path: string; name: string; icon: React.ReactElement}[] = [
-  {
-    path: `${constants.restrictedPaths.SURVEY_BUILDER}`,
-    name: 'SURVEY DESIGN',
-
-    icon: <BuildTwoToneIcon />,
-  },
+  {name: 'SURVEY DESIGN', path: `${constants.restrictedPaths.SURVEY_BUILDER}`, icon: <BuildTwoToneIcon />},
   {name: 'BRANCHING LOGIC', path: `${constants.restrictedPaths.SURVEY_BRANCHING}`, icon: <MediationTwoToneIcon />},
 ]
 
 const SurveyTopNav: FunctionComponent<SurveyTopNavProps> = ({survey, error}: SurveyTopNavProps) => {
-  const [isMobileOpen, setIsMobileOpen] = React.useState(false)
-  const classes = useStyles()
 
   const links = ALL_LINKS.map(link => ({
     ...link,

--- a/src/components/surveys/survey-branching/SurveyBranching.tsx
+++ b/src/components/surveys/survey-branching/SurveyBranching.tsx
@@ -1,11 +1,12 @@
 import ConfirmationDialog from '@components/widgets/ConfirmationDialog'
-import {Box, styled} from '@mui/material'
+import {Box, styled, Typography} from '@mui/material'
 import {useSurveyAssessment, useSurveyConfig, useUpdateSurveyConfig} from '@services/assessmentHooks'
-import {latoFont} from '@style/theme'
+import {latoFont, theme} from '@style/theme'
 import {ChoiceQuestion, Step, Survey} from '@typedefs/surveys'
 import dagre from 'dagre'
 import React, {FunctionComponent} from 'react'
 import 'reactflow/dist/style.css'
+import useFeatureToggles, {FeatureToggles, features} from '@helpers/FeatureToggle'
 
 import ReactFlow, {
   applyNodeChanges,
@@ -124,9 +125,12 @@ const SurveyBranching: FunctionComponent<SurveyBranchingProps> = () => {
   const [hasObjectChanged, setHasObjectChanged] = React.useState(false)
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number | undefined>(-1)
   const [isHideInput, setIsHideInput] = React.useState(true)
-  const isReadOnly = assessment?.isReadOnly ?? false
   const [nodes, setNodes] = React.useState<Node[]>([])
   const [edges, setEdges] = React.useState<Edge[]>([])
+  const featureToggles = useFeatureToggles<FeatureToggles>()
+  const isBranchingLogicUnlocked = (featureToggles[features.SURVEY_BRANCHING_LOGIC] ?? false)
+  const isAssessmentReadOnly = (assessment?.isReadOnly ?? false)
+  const isReadOnly = isAssessmentReadOnly || !isBranchingLogicUnlocked
 
   //dagre
   const dagreGraph = new dagre.graphlib.Graph()
@@ -228,7 +232,19 @@ const SurveyBranching: FunctionComponent<SurveyBranchingProps> = () => {
 
       <SurveyBranchingContainerBox>
         {error && <span>{error.toString()}</span>}
-        {isReadOnly && <ReadOnlyBanner label='survey' />}
+        {isAssessmentReadOnly && <ReadOnlyBanner label='survey' />}
+        {!isBranchingLogicUnlocked && 
+          <Box
+            sx={{
+              backgroundColor: 'rgba(255, 168, 37, 0.15)',
+              textAlign: 'left',
+              fontSize: '16px',
+              display: 'flex',
+              padding: theme.spacing(1, 8),
+            }}>
+            Branching logic is under development and can only be edited by the Open Bridge team.
+          </Box>
+        }
         <Box ref={ref}>
           <div
             style={{

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Completion.test.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Completion.test.tsx
@@ -28,8 +28,10 @@ const step: Step = {
   },
 }
 
+
 test('has the link to branching', async () => {
   renderComponent(step)
-  const link = screen.getByRole('link', {name: 'Preview Branching Logic'})
-  expect(link).toBeInTheDocument()
+  // TODO: syoung 11/02/2023 Uncomment once branching logic is supported on production
+  // const link = screen.getByRole('link', {name: 'Preview Branching Logic'})
+  // expect(link).toBeInTheDocument()
 })

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Completion.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Completion.tsx
@@ -1,12 +1,11 @@
-import FileUploadTwoToneIcon from '@mui/icons-material/FileUploadTwoTone'
 import MediationTwoToneIcon from '@mui/icons-material/MediationTwoTone'
 import Alert from '@mui/icons-material/ReportProblemTwoTone'
-import SettingsTwoToneIcon from '@mui/icons-material/SettingsTwoTone'
 import {Box, Button, Divider, Typography} from '@mui/material'
 import {styled} from '@mui/material/styles'
 import {theme} from '@style/theme'
 import {BaseStep} from '@typedefs/surveys'
 import {useParams} from 'react-router-dom'
+import useFeatureToggles, {FeatureToggles, features} from '@helpers/FeatureToggle'
 
 const StyledText = styled('div')(({theme}) => ({
   fontSize: '16px',
@@ -18,6 +17,7 @@ const Completion: React.FunctionComponent<{
   step: BaseStep
   onChange: (step: BaseStep) => void
 }> = () => {
+  const featureToggles = useFeatureToggles<FeatureToggles>()
   let {id: surveyGuid} = useParams<{
     id: string
   }>()
@@ -34,16 +34,18 @@ const Completion: React.FunctionComponent<{
         {' '}
         Survey Access Settings
       </Button> */}
-      <Typography sx={{fontSize: '20px', mb: 1}}> Ready to use?</Typography>
-      <StyledText> Before adding your survey to a study under design, please review any branching logic used by your questions. </StyledText>
-      <Button
-        color="primary"
-        variant="contained"
-        startIcon={<MediationTwoToneIcon />}
-        href={`/surveys/${surveyGuid}/branching`}
-        sx={{padding: theme.spacing(1, 2.5), margin: theme.spacing(1.5, 0, 5, 0)}}>
-        Preview Branching Logic
-      </Button>
+      {featureToggles[features.SURVEY_BRANCHING_LOGIC] && (<>
+        <Typography sx={{fontSize: '20px', mb: 1}}> Ready to use?</Typography>
+        <StyledText> Before adding your survey to a study under design, please review any branching logic used by your questions. </StyledText>
+        <Button
+          color="primary"
+          variant="contained"
+          startIcon={<MediationTwoToneIcon />}
+          href={`/surveys/${surveyGuid}/branching`}
+          sx={{padding: theme.spacing(1, 2.5), margin: theme.spacing(1.5, 0, 5, 0)}}>
+          Preview Branching Logic
+        </Button>
+      </>)}
       <Typography sx={{fontSize: '20px', mb: 1}}>Publish Survey</Typography>
       <Typography
         sx={{fontStyle: 'italic', fontWeight: 400, fontSize: '14px', display: 'flex', marginTop: theme.spacing(2), marginBottom: theme.spacing(1)}}>

--- a/src/helpers/FeatureToggle.tsx
+++ b/src/helpers/FeatureToggle.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react'
 
 export const features = {
   SURVEY_BUILDER: 'SURVEY BUILDER',
+  SURVEY_BRANCHING_LOGIC: 'SURVEY BRANCHING LOGIC',
   USERNAME_PASSWORD_LOGIN: 'USERNAME PASSWORD LOGIN',
   SHARED: 'SHARED',
 } as const


### PR DESCRIPTION
Found issues with the JSON config and how survey rules are being set up. In the interest of moving forward with other concerns, we're making branching logic read-only on production.